### PR TITLE
Mock http transfers in test 13

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ libstirshaken_la_LDFLAGS = -version-info 1:0:0
 pkgconfigdir   = @pkgconfigdir@
 pkgconfig_DATA = build/stirshaken.pc
 
-check_PROGRAMS = stir_shaken_test_1 stir_shaken_test_2 stir_shaken_test_3 stir_shaken_test_4 stir_shaken_test_5 stir_shaken_test_6 stir_shaken_test_7 stir_shaken_test_8 stir_shaken_test_9 stir_shaken_test_10 stir_shaken_test_11 stir_shaken_test_12 stir_shaken_test_13 stir_shaken_test_14
+check_PROGRAMS = stir_shaken_test_1 stir_shaken_test_2 stir_shaken_test_3 stir_shaken_test_4 stir_shaken_test_5 stir_shaken_test_6 stir_shaken_test_7 stir_shaken_test_8 stir_shaken_test_9 stir_shaken_test_10 stir_shaken_test_11 stir_shaken_test_12 stir_shaken_test_13 stir_shaken_test_14 stir_shaken_test_15
 TESTS = $(check_PROGRAMS)
 
 bin_PROGRAMS = stirshaken
@@ -74,3 +74,7 @@ stir_shaken_test_13_LDADD = libstirshaken.la
 stir_shaken_test_14_SOURCES = test/stir_shaken_test_14.c
 stir_shaken_test_14_CFLAGS = -Iinclude
 stir_shaken_test_14_LDADD = libstirshaken.la
+
+stir_shaken_test_15_SOURCES = test/stir_shaken_test_15.c util/src/stir_shaken_ca.c util/src/mongoose.c
+stir_shaken_test_15_CFLAGS = -Iinclude -Iutil/include
+stir_shaken_test_15_LDADD = libstirshaken.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,8 +67,8 @@ stir_shaken_test_12_SOURCES = test/stir_shaken_test_12.c
 stir_shaken_test_12_CFLAGS = -Iinclude
 stir_shaken_test_12_LDADD = libstirshaken.la
 
-stir_shaken_test_13_SOURCES = test/stir_shaken_test_13.c
-stir_shaken_test_13_CFLAGS = -Iinclude
+stir_shaken_test_13_SOURCES = test/stir_shaken_test_13.c util/src/stir_shaken_ca.c util/src/mongoose.c
+stir_shaken_test_13_CFLAGS = -Iinclude -Iutil/include -DMG_ENABLE_SSL
 stir_shaken_test_13_LDADD = libstirshaken.la
 
 stir_shaken_test_14_SOURCES = test/stir_shaken_test_14.c
@@ -76,5 +76,5 @@ stir_shaken_test_14_CFLAGS = -Iinclude
 stir_shaken_test_14_LDADD = libstirshaken.la
 
 stir_shaken_test_15_SOURCES = test/stir_shaken_test_15.c util/src/stir_shaken_ca.c util/src/mongoose.c
-stir_shaken_test_15_CFLAGS = -Iinclude -Iutil/include
+stir_shaken_test_15_CFLAGS = -Iinclude -Iutil/include -DMG_ENABLE_SSL
 stir_shaken_test_15_LDADD = libstirshaken.la

--- a/README.md
+++ b/README.md
@@ -44,33 +44,35 @@ apt-get update && apt-get install -y automake autoconf libtool libcurl4-openssl-
 
 ### Build
 
-If you just want to get on with it, then please run
 ```
-./do_install.sh
-```
-This will install dependencies as well as tools needed to make build, and will build and install it on debian buster.
-If there are problems with dependencies, then install them manually and rerun `./do_install.sh`.
-This will build all Shaken targets if packages are installed.
-
-Please run `./do_install.sh` (debian specific) or perform these manual steps:
-
-```
-./bootstrap.sh
-./configure
 make
+```
+
+
+### Install
+
+```
 sudo make install
 ```
 
+In case of troubles with build see Troubleshooting.
+
+
 ### Test
+
+Test suite can be executed with
 
 ```
 make check
 ```
 
-## stirshaken Tool
+command in main folder. There is one special test (15) which tests it all,
+it runs the complete process of SP obtaining STI cert from CA. By default this test will mock CA process and HTTP transfers,
+but it can also be tested with real CA running and HTTP transfers executed, for this run test with 'nomock' argument.
+It will download STI cert from CA, given you run it somewhere with reference data, e.g:
+	./stirshaken ca --privkey test/ref/ca/ca.priv --issuer_c US --issuer_cn "SignalWire STI-CA Test" --serial 1 --expiry 9999 --ca_cert test/ref/ca/ca.pem --uri "ca.shaken.signalwire.com/sti-ca/acme/TNAuthList" --vvv --port 8082
 
-```
-make stirshaken
+
 
 openssl req -in csr.pem -text -noout
 openssl x509 -in sp.pem -text -noout
@@ -137,3 +139,13 @@ draft-barnes-acme-service-provider, ACME Identifiers and Challenges for VoIP Ser
 * draft-ietf-stir-oob
 * draft-ietf-acme-authority-token-tnauthlist
 
+
+### Troubleshooting
+
+If build goes terribly wrong then as a last resort please have a look at 
+
+```
+./do_install.sh
+```
+
+This script contains list of steps performed initially for original build on debian 10 buster, so you can get the idea of what deps you need, etc.

--- a/include/stir_shaken.h
+++ b/include/stir_shaken.h
@@ -68,37 +68,37 @@
 #define STIR_SHAKEN_HTTPS_SKIP_HOSTNAME_VERIFICATION 0
 
 typedef struct stir_shaken_acme_nonce_s {
-    size_t	timestamp;
-    char	*response;
+	size_t	timestamp;
+	char	*response;
 } stir_shaken_acme_nonce_t;
 
 
 typedef enum stir_shaken_cert_type {
-    STIR_SHAKEN_CERT_TYPE_ROOT,
-    STIR_SHAKEN_CERT_TYPE_CA,
-    STIR_SHAKEN_CERT_TYPE_SELF_SIGNED,
+	STIR_SHAKEN_CERT_TYPE_ROOT,
+	STIR_SHAKEN_CERT_TYPE_CA,
+	STIR_SHAKEN_CERT_TYPE_SELF_SIGNED,
 } stir_shaken_cert_type_t;
 
 
 typedef enum stir_shaken_status {
-    STIR_SHAKEN_STATUS_OK,
-    STIR_SHAKEN_STATUS_FALSE,
-    STIR_SHAKEN_STATUS_ERR,
-    STIR_SHAKEN_STATUS_RESTART,
-    STIR_SHAKEN_STATUS_NOOP,
-    STIR_SHAKEN_STATUS_TERM
+	STIR_SHAKEN_STATUS_OK,
+	STIR_SHAKEN_STATUS_FALSE,
+	STIR_SHAKEN_STATUS_ERR,
+	STIR_SHAKEN_STATUS_RESTART,
+	STIR_SHAKEN_STATUS_NOOP,
+	STIR_SHAKEN_STATUS_TERM
 } stir_shaken_status_t;
 
 typedef enum stir_shaken_http_response_status {
-    STIR_SHAKEN_HTTP_RESPONSE_STATUS_COULDNT_RESOLVE_PROXY = 5,
-    STIR_SHAKEN_HTTP_RESPONSE_STATUS_COULDNT_RESOLVE_HOST = 6,
-    STIR_SHAKEN_HTTP_RESPONSE_STATUS_COULDNT_CONNECT = 7,
-    STIR_SHAKEN_HTTP_RESPONSE_STATUS_REMOTE_ACCESS_DENIED = 9
+	STIR_SHAKEN_HTTP_RESPONSE_STATUS_COULDNT_RESOLVE_PROXY = 5,
+	STIR_SHAKEN_HTTP_RESPONSE_STATUS_COULDNT_RESOLVE_HOST = 6,
+	STIR_SHAKEN_HTTP_RESPONSE_STATUS_COULDNT_CONNECT = 7,
+	STIR_SHAKEN_HTTP_RESPONSE_STATUS_REMOTE_ACCESS_DENIED = 9
 } stir_shaken_http_response_status_t;
 
 typedef struct stir_shaken_csr_s {
-    X509_REQ    *req;
-    char		*pem;
+	X509_REQ    *req;
+	char		*pem;
 } stir_shaken_csr_t;
 
 // Note:
@@ -108,44 +108,44 @@ typedef struct stir_shaken_csr_s {
 //
 // serialDec and serialHex must be freed with OPENSSL_free
 typedef struct stir_shaken_cert_s {
-    X509			*x;						// X509 end-entity Certificate
-    STACK_OF(X509)	*xchain;				// Certificate chain
-    X509_STORE_CTX	*verify_ctx;			// Verification SSL context using @store to validate cert chain against CA list and CRL
-    char        *body;
-    size_t		len;
-    uint8_t     is_fresh;
-    char		install_dir[STIR_SHAKEN_BUFLEN];			// folder, where cert must be put to be accessible with @public_url for other SPs
-    char		install_url[STIR_SHAKEN_BUFLEN];			// directory part of the publicly accessible URL
-    char		public_url[STIR_SHAKEN_BUFLEN];				// publicly accessible URL which can be used to download the certificate, this is concatenated from @install_url and cert's @name and is put into PASSporT as @x5u and @params.info
-    EC_KEY              *ec_key;
-    EVP_PKEY            *private_key;
+	X509			*x;						// X509 end-entity Certificate
+	STACK_OF(X509)	*xchain;				// Certificate chain
+	X509_STORE_CTX	*verify_ctx;			// Verification SSL context using @store to validate cert chain against CA list and CRL
+	char        *body;
+	size_t		len;
+	uint8_t     is_fresh;
+	char		install_dir[STIR_SHAKEN_BUFLEN];			// folder, where cert must be put to be accessible with @public_url for other SPs
+	char		install_url[STIR_SHAKEN_BUFLEN];			// directory part of the publicly accessible URL
+	char		public_url[STIR_SHAKEN_BUFLEN];				// publicly accessible URL which can be used to download the certificate, this is concatenated from @install_url and cert's @name and is put into PASSporT as @x5u and @params.info
+	EC_KEY              *ec_key;
+	EVP_PKEY            *private_key;
 
-    unsigned long	hash;							// hash of cert name
-    char			hashstr[STIR_SHAKEN_BUFLEN];	// hashed name as string
-    char			cert_name_hashed[STIR_SHAKEN_BUFLEN];	// hashed name with .0 appended - ready to save in CA dir for usage with X509 cert path validation check
+	unsigned long	hash;							// hash of cert name
+	char			hashstr[STIR_SHAKEN_BUFLEN];	// hashed name as string
+	char			cert_name_hashed[STIR_SHAKEN_BUFLEN];	// hashed name with .0 appended - ready to save in CA dir for usage with X509 cert path validation check
 
-    // Cert info retrieved with stir_shaken_read_cert
-    char *serialHex;
-    char *serialDec;
-    ASN1_TIME *notBefore_ASN1;
-    ASN1_TIME *notAfter_ASN1;
-    char notBefore[ASN1_DATE_LEN];
-    char notAfter[ASN1_DATE_LEN];
-    char issuer[STIR_SHAKEN_SSL_BUF_LEN];
-    char subject[STIR_SHAKEN_SSL_BUF_LEN];
-    int version;
+	// Cert info retrieved with stir_shaken_read_cert
+	char *serialHex;
+	char *serialDec;
+	ASN1_TIME *notBefore_ASN1;
+	ASN1_TIME *notAfter_ASN1;
+	char notBefore[ASN1_DATE_LEN];
+	char notAfter[ASN1_DATE_LEN];
+	char issuer[STIR_SHAKEN_SSL_BUF_LEN];
+	char subject[STIR_SHAKEN_SSL_BUF_LEN];
+	int version;
 
 } stir_shaken_cert_t;
 
 // ACME credentials
 typedef struct stir_shaken_ssl_keys {
-    EC_KEY		*ec_key;
-    EVP_PKEY	*private_key;
-    EVP_PKEY	*public_key;
-    unsigned char	priv_raw[STIR_SHAKEN_PRIV_KEY_RAW_BUF_LEN];
-    uint32_t		priv_raw_len;
-    unsigned char	pub_raw[STIR_SHAKEN_PRIV_KEY_RAW_BUF_LEN];
-    uint32_t		pub_raw_len;
+	EC_KEY		*ec_key;
+	EVP_PKEY	*private_key;
+	EVP_PKEY	*public_key;
+	unsigned char	priv_raw[STIR_SHAKEN_PRIV_KEY_RAW_BUF_LEN];
+	uint32_t		priv_raw_len;
+	unsigned char	pub_raw[STIR_SHAKEN_PRIV_KEY_RAW_BUF_LEN];
+	uint32_t		pub_raw_len;
 } stir_shaken_ssl_keys_t;
 
 typedef struct curl_slist curl_slist_t;
@@ -308,52 +308,62 @@ typedef enum stir_shaken_error {
 #define STIR_SHAKEN_HTTP_REQ_404_NOT_FOUND "404"
 
 typedef enum stir_shaken_http_req_type {
-    STIR_SHAKEN_HTTP_REQ_TYPE_GET,
-    STIR_SHAKEN_HTTP_REQ_TYPE_POST,
-    STIR_SHAKEN_HTTP_REQ_TYPE_PUT,
-    STIR_SHAKEN_HTTP_REQ_TYPE_HEAD
+	STIR_SHAKEN_HTTP_REQ_TYPE_GET,
+	STIR_SHAKEN_HTTP_REQ_TYPE_POST,
+	STIR_SHAKEN_HTTP_REQ_TYPE_PUT,
+	STIR_SHAKEN_HTTP_REQ_TYPE_HEAD
 } stir_shaken_http_req_type_t;
 
 typedef struct stir_shaken_context_s {
-    char err_buf0[STIR_SHAKEN_ERROR_BUF_LEN];
-    char err_buf1[STIR_SHAKEN_ERROR_BUF_LEN];
-    char err_buf2[STIR_SHAKEN_ERROR_BUF_LEN];
-    char err_buf3[STIR_SHAKEN_ERROR_BUF_LEN];
-    char err[4*STIR_SHAKEN_ERROR_BUF_LEN];
-    stir_shaken_error_t error;
-    uint8_t got_error;
+	char err_buf0[STIR_SHAKEN_ERROR_BUF_LEN];
+	char err_buf1[STIR_SHAKEN_ERROR_BUF_LEN];
+	char err_buf2[STIR_SHAKEN_ERROR_BUF_LEN];
+	char err_buf3[STIR_SHAKEN_ERROR_BUF_LEN];
+	char err[4*STIR_SHAKEN_ERROR_BUF_LEN];
+	stir_shaken_error_t error;
+	uint8_t got_error;
 } stir_shaken_context_t;
 
 typedef struct mem_chunk_s {
-    char    *mem;
-    size_t  size;
-    stir_shaken_context_t	*ss;
+	char    *mem;
+	size_t  size;
+	stir_shaken_context_t	*ss;
 } mem_chunk_t;
 
 // HTTP
 
 typedef enum stir_shaken_http_req_content_type {
-    STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_JSON,
-    STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_URLENCODED
+	STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_JSON,
+	STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_URLENCODED
 } stir_shaken_http_req_content_type_t;
 
 typedef struct stir_shaken_http_response_s {
-    long			code;
-    char			error[STIR_SHAKEN_BUFLEN];
-    mem_chunk_t		mem;
-    curl_slist_t	*headers;
+	long			code;
+	char			error[STIR_SHAKEN_BUFLEN];
+	mem_chunk_t		mem;
+	curl_slist_t	*headers;
 } stir_shaken_http_response_t;
 
 #define STIR_SHAKEN_HTTP_DEFAULT_REMOTE_PORT 80u
 
+typedef enum stir_shaken_action_type {
+	STIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_INIT,
+	STIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_CA_REPLY_CHALLENGE,
+	STIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_REQ_AUTHZ_DETAILS,
+	STIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_REQ_AUTHZ,
+	STIR_SHAKEN_ACTION_TYPE_SP_CERT_DOWNLOAD
+		// etc.
+} stir_shaken_action_type_t;
+
 typedef struct stir_shaken_http_req_s {
-    const char					*url;
-    uint16_t                    remote_port;
-    stir_shaken_http_req_type_t	type;
-    const char					*data;
-    curl_slist_t				*tx_headers;
-    stir_shaken_http_req_content_type_t content_type;
-    stir_shaken_http_response_t	response;
+	const char					*url;
+	uint16_t                    remote_port;
+	stir_shaken_http_req_type_t	type;
+	const char					*data;
+	curl_slist_t				*tx_headers;
+	stir_shaken_http_req_content_type_t content_type;
+	stir_shaken_http_response_t	response;
+	stir_shaken_action_type_t   action;
 } stir_shaken_http_req_t;
 
 
@@ -383,15 +393,15 @@ typedef struct stir_shaken_http_req_s {
  * @ppt_ignore - true if ppt field should not be included
  */ 
 typedef struct stir_shaken_passport_params_s {
-    const char  *x5u;
-    const char  *attest;
-    const char  *desttn_key;
-    const char  *desttn_val;
-    int         iat;
-    const char  *origtn_key;
-    const char  *origtn_val;
-    const char  *origid;
-    uint8_t     ppt_ignore;     // Should skip ppt field?
+	const char  *x5u;
+	const char  *attest;
+	const char  *desttn_key;
+	const char  *desttn_val;
+	int         iat;
+	const char  *origtn_key;
+	const char  *origtn_val;
+	const char  *origid;
+	uint8_t     ppt_ignore;     // Should skip ppt field?
 } stir_shaken_passport_params_t;
 
 /**
@@ -429,7 +439,7 @@ typedef struct stir_shaken_passport_params_s {
  * }
  */
 typedef struct stir_shaken_passport {
-    jwt_t *jwt;			// PASSport JSON Web Token
+	jwt_t *jwt;			// PASSport JSON Web Token
 } stir_shaken_passport_t;
 
 stir_shaken_status_t		stir_shaken_passport_jwt_init(stir_shaken_context_t *ss, jwt_t *jwt, stir_shaken_passport_params_t *params, unsigned char *key, uint32_t keylen);
@@ -525,19 +535,19 @@ void stir_shaken_jwt_move_to_passport(jwt_t *jwt, stir_shaken_passport_t *passpo
 /* Global Values */
 typedef struct stir_shaken_globals_s {
 
-    pthread_mutexattr_t		attr;	
-    pthread_mutex_t			mutex;	
-    uint8_t					initialised;
+	pthread_mutexattr_t		attr;	
+	pthread_mutex_t			mutex;	
+	uint8_t					initialised;
 
-    /** SSL */
-    const SSL_METHOD    *ssl_method;
-    SSL_CTX             *ssl_ctx;
-    SSL                 *ssl;
-    int                 curve_nid;                  // id of the curve in OpenSSL
-    int					tn_authlist_nid;			// OID for ext-tnAuthList
-    //ASN1_OBJECT				*tn_authlist_obj;
-    X509_STORE			*store;						// Container for CA list (list of approved CAs from STI-PA) and CRL (revocation list)
-    int					loglevel;
+	/** SSL */
+	const SSL_METHOD    *ssl_method;
+	SSL_CTX             *ssl_ctx;
+	SSL                 *ssl;
+	int                 curve_nid;                  // id of the curve in OpenSSL
+	int					tn_authlist_nid;			// OID for ext-tnAuthList
+	//ASN1_OBJECT				*tn_authlist_obj;
+	X509_STORE			*store;						// Container for CA list (list of approved CAs from STI-PA) and CRL (revocation list)
+	int					loglevel;
 } stir_shaken_globals_t;
 
 extern stir_shaken_globals_t stir_shaken_globals;
@@ -778,7 +788,7 @@ char*					stir_shaken_acme_generate_auth_challenge_response(stir_shaken_context_
 char*					stir_shaken_acme_generate_auth_challenge_details(stir_shaken_context_t *ss, char *status, const char *spc, const char *token, const char *authz_url);
 char*					stir_shaken_acme_generate_auth_polling_status(stir_shaken_context_t *ss, char *status, char *expires, char *validated, const char *spc, const char *token, const char *authz_url);
 char*					stir_shaken_acme_generate_new_account_req_payload(stir_shaken_context_t *ss, char *jwk, char *nonce, char *url, char *contact_mail, char *contact_tel, unsigned char *key, uint32_t keylen, char **json);
-stir_shaken_status_t	stir_shaken_acme_api_uri_to_spc(stir_shaken_context_t *ss, const char *uri_request, const char *api_url, char *buf, int buflen, int *uri_has_secret, unsigned long long *secret);
+stir_shaken_status_t stir_shaken_acme_api_uri_to_spc(stir_shaken_context_t *ss, const char *uri_request, const char *api_url, char *buf, int buflen, unsigned long long int *sp_code, int *uri_has_secret, unsigned long long *secret);
 stir_shaken_status_t	stir_shaken_acme_api_uri_parse(stir_shaken_context_t *ss, const char *uri_request, const char *api_url, char *arg1, int arg1_len, char *arg2, int arg2_len, int *args_n);
 char*					stir_shaken_acme_generate_spc_token(stir_shaken_context_t *ss, char *issuer, char *url, char *nb, char *na, char *spc, unsigned char *key, uint32_t keylen, char **json);
 
@@ -788,7 +798,9 @@ stir_shaken_status_t	stir_shaken_acme_respond_to_challenge(stir_shaken_context_t
 stir_shaken_status_t	stir_shaken_acme_poll(stir_shaken_context_t *ss, void *data, const char *url, uint16_t remote_port);
 stir_shaken_status_t	stir_shaken_acme_perform_authorization(stir_shaken_context_t *ss, void *data, char *spc_token, unsigned char *key, uint32_t keylen, uint16_t remote_port);
 
-stir_shaken_status_t	stir_shaken_make_http_req(stir_shaken_context_t *ss, stir_shaken_http_req_t *http_req);
+stir_shaken_status_t	(*stir_shaken_make_http_req)(stir_shaken_context_t *ss, stir_shaken_http_req_t *http_req);
+stir_shaken_status_t    stir_shaken_make_http_req_real(stir_shaken_context_t *ss, stir_shaken_http_req_t *http_req);
+extern stir_shaken_status_t    stir_shaken_make_http_req_mock(stir_shaken_context_t *ss, stir_shaken_http_req_t *http_req);
 void					stir_shaken_destroy_http_request(stir_shaken_http_req_t *http_req);
 
 /**
@@ -842,9 +854,9 @@ const char* stir_shaken_get_error(stir_shaken_context_t *ss, stir_shaken_error_t
 #define stir_shaken_set_error_if_clear(ss, description, error) stir_shaken_do_set_error_if_clear(ss, description, error, __FILE__, __LINE__)
 
 #define fprintif(level, fmt, ...)		\
-    if (stir_shaken_globals.loglevel >= level) {							\
-        fprintf(stderr, (fmt), ##__VA_ARGS__);	\
-    }
+	if (stir_shaken_globals.loglevel >= level) {							\
+		fprintf(stderr, (fmt), ##__VA_ARGS__);	\
+	}
 
 #define STIR_SHAKEN_HASH_TYPE_SHALLOW			0
 #define STIR_SHAKEN_HASH_TYPE_DEEP				1
@@ -853,10 +865,10 @@ const char* stir_shaken_get_error(stir_shaken_context_t *ss, stir_shaken_error_t
 typedef void (*stir_shaken_hash_entry_destructor)(void*);
 
 typedef struct stir_shaken_hash_entry_s {
-    size_t key;
-    void *data;
-    stir_shaken_hash_entry_destructor dctor;
-    struct stir_shaken_hash_entry_s *next;
+	size_t key;
+	void *data;
+	stir_shaken_hash_entry_destructor dctor;
+	struct stir_shaken_hash_entry_s *next;
 } stir_shaken_hash_entry_t;
 
 size_t stir_shaken_hash_hash(size_t hashsize, size_t key);
@@ -884,43 +896,44 @@ time_t stir_shaken_time_elapsed_s(time_t ts, time_t now);
 #define STI_CA_HTTP_POST	1
 
 typedef struct stir_shaken_sp_s {
-    char subject_c[STIR_SHAKEN_BUFLEN];
-    char subject_cn[STIR_SHAKEN_BUFLEN];
-    uint32_t code;
-    char *kid;
-    char *nonce;
-    stir_shaken_csr_t csr;
-    stir_shaken_cert_t cert;
-    char *nb;
-    char *na;
-    stir_shaken_ssl_keys_t keys;
-    char private_key_name[STIR_SHAKEN_BUFLEN];
-    char public_key_name[STIR_SHAKEN_BUFLEN];
-    char csr_name[STIR_SHAKEN_BUFLEN];
-    char cert_name[STIR_SHAKEN_BUFLEN];
-    char spc_token[STIR_SHAKEN_BUFLEN];
-    uint16_t port;
+	char subject_c[STIR_SHAKEN_BUFLEN];
+	char subject_cn[STIR_SHAKEN_BUFLEN];
+	uint32_t code;
+	char *kid;
+	char *nonce;
+	stir_shaken_csr_t csr;
+	stir_shaken_cert_t cert;
+	char *nb;
+	char *na;
+	stir_shaken_ssl_keys_t keys;
+	char private_key_name[STIR_SHAKEN_BUFLEN];
+	char public_key_name[STIR_SHAKEN_BUFLEN];
+	char csr_name[STIR_SHAKEN_BUFLEN];
+	char cert_name[STIR_SHAKEN_BUFLEN];
+	char spc_token[STIR_SHAKEN_BUFLEN];
+	uint16_t port;
 } stir_shaken_sp_t;
 
 typedef struct stir_shaken_ca_session_s {
-    int state;
-    size_t spc;
-    unsigned long long authz_secret;
-    char *nonce;
-    char *authz_url;
-    char *authz_token;
-    char *authz_challenge;
-    char *authz_challenge_details;
-    char *authz_polling_status;
-    int	authorized;
-    stir_shaken_sp_t sp;
-    size_t ts;
+	int state;
+	size_t spc;
+	unsigned long long authz_secret;
+	char *nonce;
+	char *authz_url;
+	char *authz_token;
+	char *authz_challenge;
+	char *authz_challenge_details;
+	char *authz_polling_status;
+	int	authorized;
+	stir_shaken_sp_t sp;
+	size_t ts;
+	uint8_t use_ssl;
 } stir_shaken_ca_session_t;
 
 typedef struct stir_shaken_ca_s {
-    stir_shaken_context_t ss;
-    stir_shaken_ssl_keys_t keys;
-    stir_shaken_cert_t cert;
+	stir_shaken_context_t ss;
+	stir_shaken_ssl_keys_t keys;
+	stir_shaken_cert_t cert;
 	char private_key_name[STIR_SHAKEN_BUFLEN];
 	char public_key_name[STIR_SHAKEN_BUFLEN];
 	char cert_name[STIR_SHAKEN_BUFLEN];
@@ -934,18 +947,23 @@ typedef struct stir_shaken_ca_s {
 	int expiry_days;
 	uint16_t port;
 	stir_shaken_hash_entry_t* sessions[STI_CA_SESSIONS_MAX];
-    uint8_t use_ssl;
+	uint8_t use_ssl;
 	char ssl_cert_name[STIR_SHAKEN_BUFLEN];
 	char ssl_key_name[STIR_SHAKEN_BUFLEN];
 } stir_shaken_ca_t;
 
 typedef struct stir_shaken_pa_s {
-    stir_shaken_ssl_keys_t keys;
-    char private_key_name[STIR_SHAKEN_BUFLEN];
-    char public_key_name[STIR_SHAKEN_BUFLEN];
-    uint16_t port;
+	stir_shaken_ssl_keys_t keys;
+	char private_key_name[STIR_SHAKEN_BUFLEN];
+	char public_key_name[STIR_SHAKEN_BUFLEN];
+	uint16_t port;
 } stir_shaken_pa_t;
 
+stir_shaken_status_t ca_sp_cert_req_reply_challenge(stir_shaken_context_t *ss, stir_shaken_ca_t *ca, char *msg, char *authz_challenge, char *authz_url, stir_shaken_ca_session_t **session_out);
+stir_shaken_status_t ca_create_session_challenge_details(stir_shaken_context_t *ss, char *status, const char *spc, char *authz_url, stir_shaken_ca_session_t *session);
+stir_shaken_status_t ca_session_prepare_polling(stir_shaken_context_t *ss, const char *msg, char *spc, char *expires, char *validated, stir_shaken_ca_session_t *session);
+stir_shaken_status_t ca_extract_spc_token_from_authz_response(stir_shaken_context_t *ss, const char *msg, const char **spc_token, jwt_t **spc_token_jwt);
+stir_shaken_status_t ca_verify_spc(stir_shaken_context_t *ss, jwt_t *spc_jwt, unsigned long long int spc);
 void stir_shaken_ca_destroy(stir_shaken_ca_t *ca);
 stir_shaken_status_t stir_shaken_run_ca_service(stir_shaken_context_t *ss, stir_shaken_ca_t *ca);
 stir_shaken_status_t stir_shaken_run_pa_service(stir_shaken_context_t *ss, stir_shaken_pa_t *pa);

--- a/src/stir_shaken_acme.c
+++ b/src/stir_shaken_acme.c
@@ -536,6 +536,11 @@ stir_shaken_status_t stir_shaken_acme_retrieve_auth_challenge_details(stir_shake
     if (!http_req)
         return STIR_SHAKEN_STATUS_TERM;
 
+    if (http_req->response.mem.mem) {
+        free(http_req->response.mem.mem);
+        http_req->response.mem.mem = NULL;
+        http_req->response.mem.size = 0;
+    }
     ss_status = stir_shaken_make_http_get_req(ss, http_req);
 
 #if STIR_SHAKEN_MOCK_ACME_AUTH_CHALLENGE_DETAILS_REQ
@@ -693,6 +698,7 @@ stir_shaken_status_t stir_shaken_acme_respond_to_challenge(stir_shaken_context_t
 
         http_req.url = strdup(challenge_url);
         http_req.remote_port = remote_port;
+        http_req.action = STIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_REQ_AUTHZ;
 
         if (STIR_SHAKEN_STATUS_OK != stir_shaken_make_http_post_req(ss, &http_req, jwt_encoded, 1)) {
             // Mock response
@@ -700,15 +706,21 @@ stir_shaken_status_t stir_shaken_acme_respond_to_challenge(stir_shaken_context_t
             //ss_status = STIR_SHAKEN_STATUS_OK;
             //http_req.response.code = 200;
             // Content is left unspecified in Step 5 of 6.3.5.2 ACME Based Steps for Application for an STI Certificate [ATIS-1000080]
+            free(jwt_encoded);
+            jwt_encoded = NULL;
             goto fail;
         }
 
         if (http_req.response.code != 200 && http_req.response.code != 201) {
             stir_shaken_set_error(ss, http_req.response.error, STIR_SHAKEN_ERROR_ACME);
+            free(jwt_encoded);
+            jwt_encoded = NULL;
             return STIR_SHAKEN_STATUS_FALSE;
         }
 
         stir_shaken_destroy_http_request(&http_req);
+        free(jwt_encoded);
+        jwt_encoded = NULL;
     }
 
     ks_json_delete(&json);
@@ -735,6 +747,7 @@ stir_shaken_status_t stir_shaken_acme_poll(stir_shaken_context_t *ss, void *data
 
     http_req.url = strdup(url);
     http_req.remote_port = remote_port;
+    http_req.action = STIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_REQ_AUTHZ;
 
     // Poll until either status is 'valid' or more than 30s passed
     while (!status_is_valid && t < 30) {
@@ -821,12 +834,19 @@ stir_shaken_status_t stir_shaken_acme_poll(stir_shaken_context_t *ss, void *data
             ks_json_delete(&json);
             json = NULL;
         }
+
+        free(http_req.response.mem.mem);
+        http_req.response.mem.mem = NULL;
+        http_req.response.mem.size = 0;
     }
+
+    stir_shaken_destroy_http_request(&http_req);
 
     return status_is_valid ? STIR_SHAKEN_STATUS_OK : STIR_SHAKEN_STATUS_FALSE;
 
 fail:
     if (json) ks_json_delete(&json);
+    stir_shaken_destroy_http_request(&http_req);
     return STIR_SHAKEN_STATUS_TERM;
 }
 
@@ -940,10 +960,17 @@ stir_shaken_status_t stir_shaken_acme_perform_authorization(stir_shaken_context_
          * Performing Step 4 of 6.3.5.2 ACME Based Steps for Application for an STI Certificate [ATIS-1000080].
          */
 
+        http_req.action = STIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_REQ_AUTHZ_DETAILS;
         http_req.url = strdup(auth_url);
         http_req.remote_port = remote_port;
 
         fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "\t-> Requesting authorization challenge details...\n");
+
+        if (http_req.response.mem.mem) {
+            free(http_req.response.mem.mem);
+            http_req.response.mem.mem = NULL;
+            http_req.response.mem.size = 0;
+        }
 
         if (STIR_SHAKEN_STATUS_OK != stir_shaken_acme_retrieve_auth_challenge_details(ss, &http_req)) {
             stir_shaken_set_error(ss, "Request for ACME authorization challenge details failed. STI-SP cert cannot be downloaded.", STIR_SHAKEN_ERROR_ACME);
@@ -985,6 +1012,7 @@ stir_shaken_status_t stir_shaken_acme_perform_authorization(stir_shaken_context_
 
             free(polling_url);
             fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "\t-> Polling finished...\n");
+            stir_shaken_destroy_http_request(&http_req);
         }
     }
 
@@ -1123,11 +1151,12 @@ exit:
     return out;
 }
 
-stir_shaken_status_t stir_shaken_acme_api_uri_to_spc(stir_shaken_context_t *ss, const char *uri_request, const char *api_url, char *buf, int buflen, int *uri_has_secret, unsigned long long *secret)
+stir_shaken_status_t stir_shaken_acme_api_uri_to_spc(stir_shaken_context_t *ss, const char *uri_request, const char *api_url, char *buf, int buflen, unsigned long long int *sp_code, int *uri_has_secret, unsigned long long *secret)
 {
-    char *p = NULL, *spc = NULL;
+    char *p = NULL, *spc = NULL, *pCh = NULL;
     char request[STIR_SHAKEN_BUFLEN] = { 0 };
     int len = 0;
+    unsigned long long int sp_code_val = 0;
 
     if (stir_shaken_zstr(uri_request)) {
         stir_shaken_set_error(ss, "Bad AUTHZ request URI", STIR_SHAKEN_ERROR_ACME_URI);
@@ -1136,6 +1165,11 @@ stir_shaken_status_t stir_shaken_acme_api_uri_to_spc(stir_shaken_context_t *ss, 
 
     if (stir_shaken_zstr(api_url)) {
         stir_shaken_set_error(ss, "Bad params, API URI missing", STIR_SHAKEN_ERROR_GENERAL);
+        return STIR_SHAKEN_STATUS_TERM;
+    }
+
+    if (!sp_code) {
+        stir_shaken_set_error(ss, "Bad params, 'sp_code' output pointer not set", STIR_SHAKEN_ERROR_GENERAL);
         return STIR_SHAKEN_STATUS_TERM;
     }
 
@@ -1178,7 +1212,6 @@ stir_shaken_status_t stir_shaken_acme_api_uri_to_spc(stir_shaken_context_t *ss, 
 
     if ((p = strchr(p, '/'))) {
 
-        char *pCh = NULL;
         unsigned long long  val;
 
         // maybe authz details URI, or cert URI
@@ -1215,6 +1248,20 @@ stir_shaken_status_t stir_shaken_acme_api_uri_to_spc(stir_shaken_context_t *ss, 
 
         strncpy(buf, spc, buflen);
     }
+
+    pCh = NULL;
+    sp_code_val = strtoul(spc, &pCh, 10); 
+    if (sp_code_val > 0x10000 - 1) { 
+        stir_shaken_set_error(ss, "SPC number too big", STIR_SHAKEN_ERROR_ACME_SPC_TOO_BIG);
+        return STIR_SHAKEN_STATUS_FALSE;
+    }
+
+    if (*pCh != '\0') { 
+        stir_shaken_set_error(ss, "SPC invalid", STIR_SHAKEN_ERROR_ACME_SPC_INVALID);
+        return STIR_SHAKEN_STATUS_FALSE;
+    }
+
+    *sp_code = sp_code_val;
 
     return STIR_SHAKEN_STATUS_OK;
 }

--- a/src/stir_shaken_service.c
+++ b/src/stir_shaken_service.c
@@ -3,47 +3,47 @@
 
 static size_t stir_shaken_curl_write_callback(void *contents, size_t size, size_t nmemb, void *p)
 {
-    char *m = NULL;
-    size_t realsize = size * nmemb;
-    stir_shaken_http_req_t *http_req = (stir_shaken_http_req_t *) p;
-    mem_chunk_t *mem = &http_req->response.mem;
+	char *m = NULL;
+	size_t realsize = size * nmemb;
+	stir_shaken_http_req_t *http_req = (stir_shaken_http_req_t *) p;
+	mem_chunk_t *mem = &http_req->response.mem;
 
-    stir_shaken_clear_error(mem->ss);
+	stir_shaken_clear_error(mem->ss);
 
-    fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "STIR-Shaken: CURL: Download progress: got %zu bytes (%zu total)\n", realsize, realsize + mem->size);
+	fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "STIR-Shaken: CURL: Download progress: got %zu bytes (%zu total)\n", realsize, realsize + mem->size);
 
-    m = realloc(mem->mem, mem->size + realsize + 1);
-    if(!m) {
-        stir_shaken_set_error(mem->ss, "realloc returned NULL", STIR_SHAKEN_ERROR_GENERAL);
-        return 0;
-    }
+	m = realloc(mem->mem, mem->size + realsize + 1);
+	if(!m) {
+		stir_shaken_set_error(mem->ss, "realloc returned NULL", STIR_SHAKEN_ERROR_GENERAL);
+		return 0;
+	}
 
-    mem->mem = m;
-    memcpy(&(mem->mem[mem->size]), contents, realsize);
-    mem->size += realsize;
-    mem->mem[mem->size] = 0;
+	mem->mem = m;
+	memcpy(&(mem->mem[mem->size]), contents, realsize);
+	mem->size += realsize;
+	mem->mem[mem->size] = 0;
 
-    return realsize;
+	return realsize;
 }
 
 static size_t stir_shaken_curl_header_callback(void *ptr, size_t size, size_t nmemb, void *data)
 {
-    register unsigned int realsize = (unsigned int) (size * nmemb);
-    stir_shaken_http_req_t *http_req = data;
-    char *header = NULL;
+	register unsigned int realsize = (unsigned int) (size * nmemb);
+	stir_shaken_http_req_t *http_req = data;
+	char *header = NULL;
 
-    header = malloc(realsize + 1);
-    if (!header) {
-        fprintif(STIR_SHAKEN_LOGLEVEL_HIGH, "STIR-Shaken: CURL: Received empty header... skipping\n");
-        return 0;
-    }
-    memcpy(header, ptr, realsize);
-    header[realsize] = '\0';
+	header = malloc(realsize + 1);
+	if (!header) {
+		fprintif(STIR_SHAKEN_LOGLEVEL_HIGH, "STIR-Shaken: CURL: Received empty header... skipping\n");
+		return 0;
+	}
+	memcpy(header, ptr, realsize);
+	header[realsize] = '\0';
 
-    http_req->response.headers = curl_slist_append(http_req->response.headers, header);
-    free(header);
+	http_req->response.headers = curl_slist_append(http_req->response.headers, header);
+	free(header);
 
-    return realsize;
+	return realsize;
 }
 
 /*
@@ -111,45 +111,45 @@ static size_t stir_shaken_curl_header_callback(void *ptr, size_t size, size_t nm
  * and valgrind deals with this situation by differentiating between actual leaks (memory to which no pointers are left) and memory which is still reachable at process termination
  * (so that it could have been used again if the process had not terminated)."
  */
-stir_shaken_status_t stir_shaken_make_http_req(stir_shaken_context_t *ss, stir_shaken_http_req_t *http_req)
+stir_shaken_status_t stir_shaken_make_http_req_real(stir_shaken_context_t *ss, stir_shaken_http_req_t *http_req)
 {
-    CURLcode		res = 0;
-    CURL			*curl_handle = NULL;
-    char			err_buf[STIR_SHAKEN_ERROR_BUF_LEN] = { 0 };
-    char			user_agent[STIR_SHAKEN_ERROR_BUF_LEN] = { 0 };
+	CURLcode		res = 0;
+	CURL			*curl_handle = NULL;
+	char			err_buf[STIR_SHAKEN_ERROR_BUF_LEN] = { 0 };
+	char			user_agent[STIR_SHAKEN_ERROR_BUF_LEN] = { 0 };
 
-    if (!http_req || !http_req->url) return STIR_SHAKEN_STATUS_RESTART;
+	if (!http_req || !http_req->url) return STIR_SHAKEN_STATUS_RESTART;
 
-    if (ss) stir_shaken_clear_error(ss);
+	if (ss) stir_shaken_clear_error(ss);
 
-    curl_global_init(CURL_GLOBAL_ALL);
-    curl_handle = curl_easy_init();
-    if (!curl_handle) return STIR_SHAKEN_STATUS_TERM;
+	curl_global_init(CURL_GLOBAL_ALL);
+	curl_handle = curl_easy_init();
+	if (!curl_handle) return STIR_SHAKEN_STATUS_TERM;
 
-    curl_easy_setopt(curl_handle, CURLOPT_URL, http_req->url);
+	curl_easy_setopt(curl_handle, CURLOPT_URL, http_req->url);
 
 #if STIR_SHAKEN_HTTPS_SKIP_PEER_VERIFICATION
-    /*
-     * If you want to connect to a site who isn't using a certificate that is
-     * signed by one of the certs in the CA bundle you have, you can skip the
-     * verification of the server's certificate. This makes the connection
-     * A LOT LESS SECURE.
-     *
-     * If you have a CA cert for the server stored someplace else than in the
-     * default bundle, then the CURLOPT_CAPATH option might come handy for
-     * you.
-     */ 
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+	/*
+	 * If you want to connect to a site who isn't using a certificate that is
+	 * signed by one of the certs in the CA bundle you have, you can skip the
+	 * verification of the server's certificate. This makes the connection
+	 * A LOT LESS SECURE.
+	 *
+	 * If you have a CA cert for the server stored someplace else than in the
+	 * default bundle, then the CURLOPT_CAPATH option might come handy for
+	 * you.
+	 */ 
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
 #endif
- 
+
 #if STIR_SHAKEN_HTTPS_SKIP_HOSTNAME_VERIFICATION
-    /*
-     * If the site you're connecting to uses a different host name that what
-     * they have mentioned in their server certificate's commonName (or
-     * subjectAltName) fields, libcurl will refuse to connect. You can skip
-     * this check, but this will make the connection less secure.
-     */ 
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+	/*
+	 * If the site you're connecting to uses a different host name that what
+	 * they have mentioned in their server certificate's commonName (or
+	 * subjectAltName) fields, libcurl will refuse to connect. You can skip
+	 * this check, but this will make the connection less secure.
+	 */ 
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 #endif
 
 	// Shared stuff
@@ -158,132 +158,138 @@ stir_shaken_status_t stir_shaken_make_http_req(stir_shaken_context_t *ss, stir_s
 	curl_easy_setopt(curl_handle, CURLOPT_HEADERFUNCTION, stir_shaken_curl_header_callback);
 	curl_easy_setopt(curl_handle, CURLOPT_HEADERDATA, (void *) http_req);
 
-    if (http_req->remote_port == 0) {
-        http_req->remote_port = STIR_SHAKEN_HTTP_DEFAULT_REMOTE_PORT;
-        fprintif(STIR_SHAKEN_LOGLEVEL_HIGH, "STIR-Shaken: changing remote port to DEFAULT %u cause port not set\n", http_req->remote_port);
-    }
+	if (http_req->response.mem.mem) {
+		free(http_req->response.mem.mem);
+		http_req->response.mem.mem = NULL;
+		http_req->response.mem.size = 0;
+	}
 
-    curl_easy_setopt(curl_handle, CURLOPT_PORT, http_req->remote_port);
+	if (http_req->remote_port == 0) {
+		http_req->remote_port = STIR_SHAKEN_HTTP_DEFAULT_REMOTE_PORT;
+		fprintif(STIR_SHAKEN_LOGLEVEL_HIGH, "STIR-Shaken: changing remote port to DEFAULT %u cause port not set\n", http_req->remote_port);
+	}
 
-    // Some pple say, some servers don't like requests that are made without a user-agent field, so we provide one.
-    snprintf(user_agent, STIR_SHAKEN_ERROR_BUF_LEN, "freeswitch-stir-shaken/%s", STIR_SHAKEN_VERSION);
-    curl_easy_setopt(curl_handle, CURLOPT_USERAGENT, user_agent);
+	curl_easy_setopt(curl_handle, CURLOPT_PORT, http_req->remote_port);
 
-    switch (http_req->type) {
+	// Some pple say, some servers don't like requests that are made without a user-agent field, so we provide one.
+	snprintf(user_agent, STIR_SHAKEN_ERROR_BUF_LEN, "freeswitch-stir-shaken/%s", STIR_SHAKEN_VERSION);
+	curl_easy_setopt(curl_handle, CURLOPT_USERAGENT, user_agent);
 
-        case STIR_SHAKEN_HTTP_REQ_TYPE_GET:	
+	switch (http_req->type) {
 
-            curl_easy_setopt(curl_handle, CURLOPT_HTTPGET, 1);
-            break;
+		case STIR_SHAKEN_HTTP_REQ_TYPE_GET:	
 
-        case STIR_SHAKEN_HTTP_REQ_TYPE_POST:
+			curl_easy_setopt(curl_handle, CURLOPT_HTTPGET, 1);
+			break;
 
-            if (http_req->data) {
-                curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDSIZE, strlen(http_req->data));
-                curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDS, (void *) http_req->data);
-            }
+		case STIR_SHAKEN_HTTP_REQ_TYPE_POST:
 
-            // Curl will send form urlencoded by default, so for json the Content-Type header must be explicitly set
-            switch (http_req->content_type) {
+			if (http_req->data) {
+				curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDSIZE, strlen(http_req->data));
+				curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDS, (void *) http_req->data);
+			}
 
-                case STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_JSON:
+			// Curl will send form urlencoded by default, so for json the Content-Type header must be explicitly set
+			switch (http_req->content_type) {
 
-                    http_req->tx_headers = curl_slist_append(http_req->tx_headers, "Content-Type: application/json");
-                    break;
+				case STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_JSON:
 
-                case STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_URLENCODED:
-                default:
-                    break;
-            }
+					http_req->tx_headers = curl_slist_append(http_req->tx_headers, "Content-Type: application/json");
+					break;
 
-            break;
+				case STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_URLENCODED:
+				default:
+					break;
+			}
 
-        case STIR_SHAKEN_HTTP_REQ_TYPE_PUT:
-            break;
+			break;
 
-        case STIR_SHAKEN_HTTP_REQ_TYPE_HEAD:	
+		case STIR_SHAKEN_HTTP_REQ_TYPE_PUT:
+			break;
 
-            // TODO check if this is necessary to make HEAD req
-            //curl_easy_setopt(curl_handle, CURLOPT_CUSTOMREQUEST, "HEAD");
+		case STIR_SHAKEN_HTTP_REQ_TYPE_HEAD:	
 
-            // Get the resource without a body
-            curl_easy_setopt(curl_handle, CURLOPT_NOBODY, 1L);
+			// TODO check if this is necessary to make HEAD req
+			//curl_easy_setopt(curl_handle, CURLOPT_CUSTOMREQUEST, "HEAD");
 
-            break;
+			// Get the resource without a body
+			curl_easy_setopt(curl_handle, CURLOPT_NOBODY, 1L);
 
-        default:
-            stir_shaken_set_error(ss, "Unknown HTTP type Request", STIR_SHAKEN_ERROR_HTTP_GENERAL);
-            return STIR_SHAKEN_STATUS_FALSE;
-    }
+			break;
 
-    if (http_req->tx_headers) {
-        curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, http_req->tx_headers);
-    }
+		default:
+			stir_shaken_set_error(ss, "Unknown HTTP type Request", STIR_SHAKEN_ERROR_HTTP_GENERAL);
+			return STIR_SHAKEN_STATUS_FALSE;
+	}
 
-    // TODO remove
-    if (http_req->data) {
-        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "STIR-Shaken: making HTTP (%s) call:\nurl:\t%s\nport:\t%u\ndata:\t%s\n", http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_GET ? "GET" : (http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_POST ? "POST" : (http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_PUT ? "PUT" : (http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_HEAD ? "HEAD" : "BAD REQUEST"))), http_req->url, http_req->remote_port, http_req->data);
-    } else {
-        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "STIR-Shaken: making HTTP (%s) call:\nurl:\t%s\nport:\t%u\n", http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_GET ? "GET" : http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_POST ? "POST" : http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_PUT ? "PUT" : http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_HEAD ? "HEAD" : "BAD REQUEST", http_req->url, http_req->remote_port);
-    }
+	if (http_req->tx_headers) {
+		curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, http_req->tx_headers);
+	}
 
-    res = curl_easy_perform(curl_handle);
-    http_req->response.code = res;
+	// TODO remove
+	if (http_req->data) {
+		fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "STIR-Shaken: making HTTP (%s) call:\nurl:\t%s\nport:\t%u\ndata:\t%s\n", http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_GET ? "GET" : (http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_POST ? "POST" : (http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_PUT ? "PUT" : (http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_HEAD ? "HEAD" : "BAD REQUEST"))), http_req->url, http_req->remote_port, http_req->data);
+	} else {
+		fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "STIR-Shaken: making HTTP (%s) call:\nurl:\t%s\nport:\t%u\n", http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_GET ? "GET" : http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_POST ? "POST" : http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_PUT ? "PUT" : http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_HEAD ? "HEAD" : "BAD REQUEST", http_req->url, http_req->remote_port);
+	}
 
-    if (res != CURLE_OK) {
+	res = curl_easy_perform(curl_handle);
+	http_req->response.code = res;
 
-        sprintf(err_buf, "Error in CURL: %s", curl_easy_strerror(res));
-        stir_shaken_set_error(ss, err_buf, STIR_SHAKEN_ERROR_CURL); 
+	if (res != CURLE_OK) {
 
-        // Do not curl_global_cleanup in case of error, cause otherwise (if also curl_global_cleanup) SSL starts to mulfunction ???? (EVP_get_digestbyname("sha256") in stir_shaken_do_verify_data returns NULL)
-        curl_easy_cleanup(curl_handle);
-        curl_global_cleanup();
+		sprintf(err_buf, "Error in CURL: %s", curl_easy_strerror(res));
+		stir_shaken_set_error(ss, err_buf, STIR_SHAKEN_ERROR_CURL); 
 
-        return STIR_SHAKEN_STATUS_FALSE;
-    }
+		// Do not curl_global_cleanup in case of error, cause otherwise (if also curl_global_cleanup) SSL starts to mulfunction ???? (EVP_get_digestbyname("sha256") in stir_shaken_do_verify_data returns NULL)
+		curl_easy_cleanup(curl_handle);
+		curl_global_cleanup();
 
-    curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &http_req->response.code);
-    if (http_req->response.code != 200 && http_req->response.code != 201) {
-        sprintf(http_req->response.error, "HTTP response code: %ld (%s%s), HTTP response phrase: %s", http_req->response.code, curl_easy_strerror(http_req->response.code), (http_req->response.code == 400 || http_req->response.code == 404) ? " [Bad URL or API call not handled?]" : "", http_req->response.headers && http_req->response.headers->data ? http_req->response.headers->data : "");
-    }
-    curl_easy_cleanup(curl_handle);
-    curl_global_cleanup();
+		return STIR_SHAKEN_STATUS_FALSE;
+	}
 
-    // fprintf(stdout, "\n//////////////// HTTP GOT:\n%s\n///////////////////////\n", http_req->response.mem.mem);	
+	curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &http_req->response.code);
+	if (http_req->response.code != 200 && http_req->response.code != 201) {
+		sprintf(http_req->response.error, "HTTP response code: %ld (%s%s), HTTP response phrase: %s", http_req->response.code, curl_easy_strerror(http_req->response.code), (http_req->response.code == 400 || http_req->response.code == 404) ? " [Bad URL or API call not handled?]" : "", http_req->response.headers && http_req->response.headers->data ? http_req->response.headers->data : "");
+	}
+	curl_easy_cleanup(curl_handle);
+	curl_global_cleanup();
 
-    // On success, http_req->response.code is HTTP response code (200, 403, 404, etc...)
-    return STIR_SHAKEN_STATUS_OK;
+	// fprintf(stdout, "\n//////////////// HTTP GOT:\n%s\n///////////////////////\n", http_req->response.mem.mem);	
+
+	// On success, http_req->response.code is HTTP response code (200, 403, 404, etc...)
+	return STIR_SHAKEN_STATUS_OK;
 }
 
 void stir_shaken_destroy_http_request(stir_shaken_http_req_t *http_req)
 {
-    if (!http_req) return;
+	if (!http_req) return;
 
-    if (http_req->url) {
-        free((char *) http_req->url);
-        http_req->url = NULL;
-    }
+	if (http_req->url) {
+		free((char *) http_req->url);
+		http_req->url = NULL;
+	}
 
-    if (http_req->data) {
-        free((char *) http_req->data);
-        http_req->data = NULL;
-    }
+	if (http_req->data) {
+		free((char *) http_req->data);
+		http_req->data = NULL;
+	}
 
-    if (http_req->response.mem.mem) {
-        free(http_req->response.mem.mem);
-        http_req->response.mem.mem = NULL;
-    }
+	if (http_req->response.mem.mem) {
+		free(http_req->response.mem.mem);
+		http_req->response.mem.mem = NULL;
+	}
 
-    if (http_req->tx_headers) {
-        curl_slist_free_all(http_req->tx_headers);
-        http_req->tx_headers = NULL;
-    }
+	if (http_req->tx_headers) {
+		curl_slist_free_all(http_req->tx_headers);
+		http_req->tx_headers = NULL;
+	}
 
-    if (http_req->response.headers) {
-        curl_slist_free_all(http_req->response.headers);
-        http_req->response.headers = NULL;
-    }
-    memset(http_req, 0, sizeof(*http_req));
+	if (http_req->response.headers) {
+		curl_slist_free_all(http_req->response.headers);
+		http_req->response.headers = NULL;
+	}
+	memset(http_req, 0, sizeof(*http_req));
 }
 
 /**
@@ -293,26 +299,26 @@ void stir_shaken_destroy_http_request(stir_shaken_http_req_t *http_req)
  */
 stir_shaken_status_t stir_shaken_stisp_make_code_token_request(stir_shaken_context_t *ss, stir_shaken_http_req_t *http_req, const char *url, const char *fingerprint)
 {
-    if (!http_req) {
-        stir_shaken_set_error(ss, "Bad params", STIR_SHAKEN_ERROR_HTTP_PARAMS);
-        return STIR_SHAKEN_STATUS_FALSE;
-    }
+	if (!http_req) {
+		stir_shaken_set_error(ss, "Bad params", STIR_SHAKEN_ERROR_HTTP_PARAMS);
+		return STIR_SHAKEN_STATUS_FALSE;
+	}
 
-    if (stir_shaken_zstr(http_req->url)) {
-        stir_shaken_set_error(ss, "URL missing", STIR_SHAKEN_ERROR_HTTP_PARAMS);
-        return STIR_SHAKEN_STATUS_FALSE;
-    }
+	if (stir_shaken_zstr(http_req->url)) {
+		stir_shaken_set_error(ss, "URL missing", STIR_SHAKEN_ERROR_HTTP_PARAMS);
+		return STIR_SHAKEN_STATUS_FALSE;
+	}
 
-    if (stir_shaken_zstr(fingerprint)) {
-        stir_shaken_set_error(ss, "Fingerprint missing", STIR_SHAKEN_ERROR_HTTP_PARAMS);
-        return STIR_SHAKEN_STATUS_FALSE;
-    }
+	if (stir_shaken_zstr(fingerprint)) {
+		stir_shaken_set_error(ss, "Fingerprint missing", STIR_SHAKEN_ERROR_HTTP_PARAMS);
+		return STIR_SHAKEN_STATUS_FALSE;
+	}
 
-    http_req->type = STIR_SHAKEN_HTTP_REQ_TYPE_POST;
-    http_req->data = strdup(fingerprint); // TODO change to JSON if it is not JSON already
-    http_req->content_type = STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_JSON;
+	http_req->type = STIR_SHAKEN_HTTP_REQ_TYPE_POST;
+	http_req->data = strdup(fingerprint); // TODO change to JSON if it is not JSON already
+	http_req->content_type = STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_JSON;
 
-    return stir_shaken_make_http_req(ss, http_req);
+	return stir_shaken_make_http_req(ss, http_req);
 }
 
 /**
@@ -323,169 +329,174 @@ stir_shaken_status_t stir_shaken_stisp_make_code_token_request(stir_shaken_conte
  */
 stir_shaken_status_t stir_shaken_vs_verify_stica(stir_shaken_context_t *ss, stir_shaken_cert_t *cert, ks_json_t *array)
 {
-    unsigned char key[STIR_SHAKEN_PUB_KEY_RAW_BUF_LEN] = { 0 };
-    int key_len = STIR_SHAKEN_PUB_KEY_RAW_BUF_LEN;
-    ks_json_t *iterator = NULL;
+	unsigned char key[STIR_SHAKEN_PUB_KEY_RAW_BUF_LEN] = { 0 };
+	int key_len = STIR_SHAKEN_PUB_KEY_RAW_BUF_LEN;
+	ks_json_t *iterator = NULL;
 
-    if (!cert || !array) return STIR_SHAKEN_STATUS_TERM;
+	if (!cert || !array) return STIR_SHAKEN_STATUS_TERM;
 
-    if (stir_shaken_get_pubkey_raw_from_cert(ss, cert, key, &key_len) != STIR_SHAKEN_STATUS_OK) {
+	if (stir_shaken_get_pubkey_raw_from_cert(ss, cert, key, &key_len) != STIR_SHAKEN_STATUS_OK) {
 
-        stir_shaken_set_error(ss, "Cannot get public key from cert", STIR_SHAKEN_ERROR_GENERAL);
-        return STIR_SHAKEN_STATUS_FALSE;
-    }
+		stir_shaken_set_error(ss, "Cannot get public key from cert", STIR_SHAKEN_ERROR_GENERAL);
+		return STIR_SHAKEN_STATUS_FALSE;
+	}
 
-    KS_JSON_ARRAY_FOREACH(iterator, array) {
+	KS_JSON_ARRAY_FOREACH(iterator, array) {
 
-        if (ks_json_type_get(iterator) == KS_JSON_TYPE_STRING) {
-            const char *valuestring = ks_json_value_string(iterator);
-            // TODO remove
-            fprintif(STIR_SHAKEN_LOGLEVEL_HIGH, "%s\n", valuestring);
+		if (ks_json_type_get(iterator) == KS_JSON_TYPE_STRING) {
+			const char *valuestring = ks_json_value_string(iterator);
+			// TODO remove
+			fprintif(STIR_SHAKEN_LOGLEVEL_HIGH, "%s\n", valuestring);
 
-            if (strcmp((const char *)key, valuestring)) {
-                return STIR_SHAKEN_STATUS_OK;
-            }
-        } else {
+			if (strcmp((const char *)key, valuestring)) {
+				return STIR_SHAKEN_STATUS_OK;
+			}
+		} else {
 
-            fprintif(STIR_SHAKEN_LOGLEVEL_HIGH, "invalid\n");
-        }
-    }
+			fprintif(STIR_SHAKEN_LOGLEVEL_HIGH, "invalid\n");
+		}
+	}
 
-    return STIR_SHAKEN_STATUS_FALSE;
+	return STIR_SHAKEN_STATUS_FALSE;
 }
 
 stir_shaken_status_t stir_shaken_make_authority_over_number_check_req(stir_shaken_context_t *ss, const char *url, const char *origin_identity)
 {
-    stir_shaken_http_req_t http_req = { 0 };
-    char req_url[STIR_SHAKEN_BUFLEN] = { 0 };
-    stir_shaken_status_t result = STIR_SHAKEN_STATUS_FALSE;
-    ks_json_t *json = NULL, *authority_check_result = NULL;
-    char *valuestring = NULL;
+	stir_shaken_http_req_t http_req = { 0 };
+	char req_url[STIR_SHAKEN_BUFLEN] = { 0 };
+	stir_shaken_status_t result = STIR_SHAKEN_STATUS_FALSE;
+	ks_json_t *json = NULL, *authority_check_result = NULL;
+	char *valuestring = NULL;
 
-    if (stir_shaken_zstr(url)) {
-        stir_shaken_set_error(ss, "URL missing", STIR_SHAKEN_ERROR_HTTP_PARAMS);
-        return STIR_SHAKEN_STATUS_TERM;
-    }
+	if (stir_shaken_zstr(url)) {
+		stir_shaken_set_error(ss, "URL missing", STIR_SHAKEN_ERROR_HTTP_PARAMS);
+		return STIR_SHAKEN_STATUS_TERM;
+	}
 
-    if (stir_shaken_zstr(origin_identity)) {
-        stir_shaken_set_error(ss, "Origin identity missing", STIR_SHAKEN_ERROR_HTTP_PARAMS);
-        return STIR_SHAKEN_STATUS_TERM;
-    }
+	if (stir_shaken_zstr(origin_identity)) {
+		stir_shaken_set_error(ss, "Origin identity missing", STIR_SHAKEN_ERROR_HTTP_PARAMS);
+		return STIR_SHAKEN_STATUS_TERM;
+	}
 
-    snprintf(req_url, STIR_SHAKEN_BUFLEN, "%s/%s", url, origin_identity); 
-    http_req.url = strdup(req_url);
+	snprintf(req_url, STIR_SHAKEN_BUFLEN, "%s/%s", url, origin_identity); 
+	http_req.url = strdup(req_url);
 
-    if (STIR_SHAKEN_STATUS_OK != stir_shaken_make_http_get_req(ss, &http_req)) {
-        stir_shaken_set_error(ss, "HTTP request for authority over number check failed", STIR_SHAKEN_ERROR_HTTP_GENERAL);
-        goto fail;
-    }
+	if (STIR_SHAKEN_STATUS_OK != stir_shaken_make_http_get_req(ss, &http_req)) {
+		stir_shaken_set_error(ss, "HTTP request for authority over number check failed", STIR_SHAKEN_ERROR_HTTP_GENERAL);
+		goto fail;
+	}
 
-    json = ks_json_parse(http_req.response.mem.mem);
-    if (!json) {
-        stir_shaken_set_error(ss, "Error parsing into JSON", STIR_SHAKEN_ERROR_JSON);
-        goto fail;
-    }
+	json = ks_json_parse(http_req.response.mem.mem);
+	if (!json) {
+		stir_shaken_set_error(ss, "Error parsing into JSON", STIR_SHAKEN_ERROR_JSON);
+		goto fail;
+	}
 
-    authority_check_result = ks_json_get_object_item(json, "authority");
-    if (!authority_check_result) {
-        stir_shaken_set_error(ss, "Bad JSON, no 'authority' field", STIR_SHAKEN_ERROR_JSON);
-        goto fail;
-    }
+	authority_check_result = ks_json_get_object_item(json, "authority");
+	if (!authority_check_result) {
+		stir_shaken_set_error(ss, "Bad JSON, no 'authority' field", STIR_SHAKEN_ERROR_JSON);
+		goto fail;
+	}
 
-    if (ks_json_type_get(authority_check_result) != KS_JSON_TYPE_STRING) {
-        stir_shaken_set_error(ss, "Bad JSON, 'authority' field is not a string", STIR_SHAKEN_ERROR_JSON);
-        goto fail;
-    }
+	if (ks_json_type_get(authority_check_result) != KS_JSON_TYPE_STRING) {
+		stir_shaken_set_error(ss, "Bad JSON, 'authority' field is not a string", STIR_SHAKEN_ERROR_JSON);
+		goto fail;
+	}
 
-    if (strcmp("true", ks_json_value_string(authority_check_result)) == 0) {
-        result = STIR_SHAKEN_STATUS_OK;
-    } else {
-        result = STIR_SHAKEN_STATUS_FALSE;
-    }
+	if (strcmp("true", ks_json_value_string(authority_check_result)) == 0) {
+		result = STIR_SHAKEN_STATUS_OK;
+	} else {
+		result = STIR_SHAKEN_STATUS_FALSE;
+	}
 
-    stir_shaken_destroy_http_request(&http_req);
-    return result;
+	stir_shaken_destroy_http_request(&http_req);
+	return result;
 
 fail:
-    stir_shaken_destroy_http_request(&http_req);
-    return STIR_SHAKEN_STATUS_FALSE;
+	stir_shaken_destroy_http_request(&http_req);
+	return STIR_SHAKEN_STATUS_FALSE;
 }
 
 stir_shaken_status_t stir_shaken_make_http_get_req(stir_shaken_context_t *ss, stir_shaken_http_req_t *http_req)
 {
-    if (!http_req) {
-        stir_shaken_set_error(ss, "Bad params", STIR_SHAKEN_ERROR_HTTP_PARAMS);
-        return STIR_SHAKEN_STATUS_FALSE;
-    }
+	if (!http_req) {
+		stir_shaken_set_error(ss, "Bad params", STIR_SHAKEN_ERROR_HTTP_PARAMS);
+		return STIR_SHAKEN_STATUS_FALSE;
+	}
 
-    if (stir_shaken_zstr(http_req->url)) {
-        stir_shaken_set_error(ss, "URL missing", STIR_SHAKEN_ERROR_HTTP_PARAMS);
-        return STIR_SHAKEN_STATUS_FALSE;
-    }
+	if (stir_shaken_zstr(http_req->url)) {
+		stir_shaken_set_error(ss, "URL missing", STIR_SHAKEN_ERROR_HTTP_PARAMS);
+		return STIR_SHAKEN_STATUS_FALSE;
+	}
 
-    http_req->type = STIR_SHAKEN_HTTP_REQ_TYPE_GET;
+	http_req->type = STIR_SHAKEN_HTTP_REQ_TYPE_GET;
 
-    return stir_shaken_make_http_req(ss, http_req);
+	return stir_shaken_make_http_req(ss, http_req);
 }
 
 stir_shaken_status_t stir_shaken_make_http_post_req(stir_shaken_context_t *ss, stir_shaken_http_req_t *http_req, char *data, uint8_t is_json)
 {
-    if (!http_req) {
-        stir_shaken_set_error(ss, "Bad params", STIR_SHAKEN_ERROR_HTTP_PARAMS);
-        return STIR_SHAKEN_STATUS_FALSE;
-    }
+	if (!http_req) {
+		stir_shaken_set_error(ss, "Bad params", STIR_SHAKEN_ERROR_HTTP_PARAMS);
+		return STIR_SHAKEN_STATUS_FALSE;
+	}
 
-    if (stir_shaken_zstr(http_req->url)) {
-        stir_shaken_set_error(ss, "URL missing", STIR_SHAKEN_ERROR_HTTP_PARAMS);
-        return STIR_SHAKEN_STATUS_FALSE;
-    }
+	if (stir_shaken_zstr(http_req->url)) {
+		stir_shaken_set_error(ss, "URL missing", STIR_SHAKEN_ERROR_HTTP_PARAMS);
+		return STIR_SHAKEN_STATUS_FALSE;
+	}
 
-    http_req->type = STIR_SHAKEN_HTTP_REQ_TYPE_POST;
-    if (data) {
-        http_req->data = strdup(data);
-    }
+	http_req->type = STIR_SHAKEN_HTTP_REQ_TYPE_POST;
+	if (data) {
+		if (http_req->response.mem.mem) {
+			free(http_req->response.mem.mem);
+			http_req->response.mem.mem = NULL;
+			http_req->response.mem.size = 0;
+		}
+		http_req->data = strdup(data);
+	}
 
-    if (is_json) {
-        http_req->content_type = STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_JSON;
-    } else {
-        http_req->content_type = STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_URLENCODED;
-    }
+	if (is_json) {
+		http_req->content_type = STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_JSON;
+	} else {
+		http_req->content_type = STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_URLENCODED;
+	}
 
-    return stir_shaken_make_http_req(ss, http_req);
+	return stir_shaken_make_http_req(ss, http_req);
 }
 
 stir_shaken_status_t stir_shaken_make_http_head_req(stir_shaken_context_t *ss, stir_shaken_http_req_t *http_req, char *data, uint8_t is_json)
 {
-    if (!http_req) {
-        stir_shaken_set_error(ss, "Bad params", STIR_SHAKEN_ERROR_HTTP_PARAMS);
-        return STIR_SHAKEN_STATUS_FALSE;
-    }
+	if (!http_req) {
+		stir_shaken_set_error(ss, "Bad params", STIR_SHAKEN_ERROR_HTTP_PARAMS);
+		return STIR_SHAKEN_STATUS_FALSE;
+	}
 
-    if (stir_shaken_zstr(http_req->url)) {
-        stir_shaken_set_error(ss, "URL missing", STIR_SHAKEN_ERROR_HTTP_PARAMS);
-        return STIR_SHAKEN_STATUS_FALSE;
-    }
+	if (stir_shaken_zstr(http_req->url)) {
+		stir_shaken_set_error(ss, "URL missing", STIR_SHAKEN_ERROR_HTTP_PARAMS);
+		return STIR_SHAKEN_STATUS_FALSE;
+	}
 
-    http_req->type = STIR_SHAKEN_HTTP_REQ_TYPE_HEAD;
-    if (data) {
-        http_req->data = strdup(data);
-    }
+	http_req->type = STIR_SHAKEN_HTTP_REQ_TYPE_HEAD;
+	if (data) {
+		http_req->data = strdup(data);
+	}
 
-    if (is_json) {
-        http_req->content_type = STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_JSON;
-    } else {
-        http_req->content_type = STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_URLENCODED;
-    }
+	if (is_json) {
+		http_req->content_type = STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_JSON;
+	} else {
+		http_req->content_type = STIR_SHAKEN_HTTP_REQ_CONTENT_TYPE_URLENCODED;
+	}
 
-    return stir_shaken_make_http_req(ss, http_req);
+	return stir_shaken_make_http_req(ss, http_req);
 }
 
 void stir_shaken_http_add_header(stir_shaken_http_req_t *http_req, const char *h)
 {
-    if (!http_req || !h) return;
+	if (!http_req || !h) return;
 
-    /* Add a custom header */
-    http_req->tx_headers = curl_slist_append(http_req->tx_headers, h);
+	/* Add a custom header */
+	http_req->tx_headers = curl_slist_append(http_req->tx_headers, h);
 }
 
 /**
@@ -494,81 +505,81 @@ void stir_shaken_http_add_header(stir_shaken_http_req_t *http_req, const char *h
  */ 
 char* stir_shaken_get_http_header(stir_shaken_http_req_t *http_req, char *name)
 {
-    char *data = NULL, *found = NULL;
-    curl_slist_t *header = NULL;
-    int sanity = 10000;
+	char *data = NULL, *found = NULL;
+	curl_slist_t *header = NULL;
+	int sanity = 10000;
 
-    if (!http_req || !name) return NULL;
+	if (!http_req || !name) return NULL;
 
-    header = http_req->response.headers;
+	header = http_req->response.headers;
 
-    // Parse header data
-    while (header && sanity--) {
+	// Parse header data
+	while (header && sanity--) {
 
-        // Remove trailing \r
-        if ((data =  strrchr(header->data, '\r'))) {
-            *data = '\0';
-        }
+		// Remove trailing \r
+		if ((data =  strrchr(header->data, '\r'))) {
+			*data = '\0';
+		}
 
-        if (!header->data || *header->data == '\0') {
-            header = header->next;
-            continue;
-        }
+		if (!header->data || *header->data == '\0') {
+			header = header->next;
+			continue;
+		}
 
-        if ((data = strchr(header->data, ':'))) {
+		if ((data = strchr(header->data, ':'))) {
 
-            *data = '\0';
-            data++;
-            while (*data == ' ' && *data != '\0') {
-                data++;
-            }
+			*data = '\0';
+			data++;
+			while (*data == ' ' && *data != '\0') {
+				data++;
+			}
 
-            fprintif(STIR_SHAKEN_LOGLEVEL_HIGH, "key:\t\t%s\n", header->data);
-            fprintif(STIR_SHAKEN_LOGLEVEL_HIGH, "value:\t\t%s\n\n", data);
+			fprintif(STIR_SHAKEN_LOGLEVEL_HIGH, "key:\t\t%s\n", header->data);
+			fprintif(STIR_SHAKEN_LOGLEVEL_HIGH, "value:\t\t%s\n\n", data);
 
-            if (!strcmp(header->data, name)) {
+			if (!strcmp(header->data, name)) {
 
-                // found
-                found = data;
-            }
+				// found
+				found = data;
+			}
 
-        } else {
+		} else {
 
-            if (!strncmp("HTTP", header->data, 4)) {
-                fprintif(STIR_SHAKEN_LOGLEVEL_HIGH, "Starts with HTTP: %s\n", header->data);
-            } else {
-                fprintif(STIR_SHAKEN_LOGLEVEL_HIGH, "Unparsable header: %s\n", header->data);
-            }
-        }
-        header = header->next;
-    }
+			if (!strncmp("HTTP", header->data, 4)) {
+				fprintif(STIR_SHAKEN_LOGLEVEL_HIGH, "Starts with HTTP: %s\n", header->data);
+			} else {
+				fprintif(STIR_SHAKEN_LOGLEVEL_HIGH, "Unparsable header: %s\n", header->data);
+			}
+		}
+		header = header->next;
+	}
 
-    return found;
+	return found;
 }
 
 void stir_shaken_error_desc_to_http_error_phrase(const char *error_desc, char *error_phrase, int buflen)
 {
-    char *p = NULL, *d = NULL;
+	char *p = NULL, *d = NULL;
 
-    if (stir_shaken_zstr(error_desc) || !error_phrase || buflen < 1) {
-        return;
-    }
+	if (stir_shaken_zstr(error_desc) || !error_phrase || buflen < 1) {
+		return;
+	}
 
-    strncpy(error_phrase, error_desc, buflen);
-    p = error_phrase;
-    while (p && (*p != '\0')) {
+	strncpy(error_phrase, error_desc, buflen);
+	p = error_phrase;
+	while (p && (*p != '\0')) {
 
-        d = p;
-        if ((p = strstr(d, "\r\n"))) {
-            *p = ';';
-            p++;
-            *p = ' ';
-        } else {
-            if ((p = strstr(d, "\n"))) {
-                *p = ';';
-            } else {
-                return;
-            }
-        }
-    }
+		d = p;
+		if ((p = strstr(d, "\r\n"))) {
+			*p = ';';
+			p++;
+			*p = ' ';
+		} else {
+			if ((p = strstr(d, "\n"))) {
+				*p = ';';
+			} else {
+				return;
+			}
+		}
+	}
 }

--- a/src/stir_shaken_sp.c
+++ b/src/stir_shaken_sp.c
@@ -4,198 +4,196 @@
 stir_shaken_status_t stir_shaken_sp_cert_req(stir_shaken_context_t *ss, stir_shaken_http_req_t *http_req, char *jwt, unsigned char *key, uint32_t keylen, const char *spc, char *spc_token)
 {
     stir_shaken_status_t	ss_status = STIR_SHAKEN_STATUS_FALSE;
-	char cert_download_url[STIR_SHAKEN_BUFLEN] = { 0 };
+    char cert_download_url[STIR_SHAKEN_BUFLEN] = { 0 };
     uint16_t remote_port = STIR_SHAKEN_HTTP_DEFAULT_REMOTE_PORT;
 
-	if (!http_req) {
-		stir_shaken_set_error(ss, "Bad params", STIR_SHAKEN_ERROR_GENERAL);
-		return STIR_SHAKEN_STATUS_TERM;
-	}
+    if (!http_req) {
+        stir_shaken_set_error(ss, "Bad params", STIR_SHAKEN_ERROR_GENERAL);
+        return STIR_SHAKEN_STATUS_TERM;
+    }
 
     remote_port = http_req->remote_port;
 
-	if (stir_shaken_zstr(http_req->url)) {
-		stir_shaken_set_error(ss, "URL missing", STIR_SHAKEN_ERROR_GENERAL);
-		return STIR_SHAKEN_STATUS_TERM;
-	}
-	
-	if (stir_shaken_zstr(spc)) {
-		stir_shaken_set_error(ss, "SPC missing", STIR_SHAKEN_ERROR_GENERAL);
-		return STIR_SHAKEN_STATUS_TERM;
-	}
-	snprintf(cert_download_url, STIR_SHAKEN_BUFLEN, "%s/%s", http_req->url, spc);
-	
-	if (stir_shaken_zstr(jwt)) {
-		stir_shaken_set_error(ss, "JWT missing", STIR_SHAKEN_ERROR_GENERAL);
-		return STIR_SHAKEN_STATUS_TERM;
-	}
-	
-	if (!key) {
-		stir_shaken_set_error(ss, "Key not set", STIR_SHAKEN_ERROR_GENERAL);
-		return STIR_SHAKEN_STATUS_TERM;
-	}
-	
-	if (keylen < 1) {
-		stir_shaken_set_error(ss, "Invalid key. Key length must be > 0", STIR_SHAKEN_ERROR_GENERAL);
-		return STIR_SHAKEN_STATUS_TERM;
-	}
-	
-	if (stir_shaken_zstr(spc_token)) {
-		stir_shaken_set_error(ss, "SPC token missing", STIR_SHAKEN_ERROR_GENERAL);
-		return STIR_SHAKEN_STATUS_TERM;
-	}
-	
-	/**
-	 * Make cert req.
-	 * Performing Step 1 of 6.3.5.2 ACME Based Steps for Application for an STI Certificate [ATIS-1000080].
-	 */
-	ss_status = stir_shaken_make_http_post_req(ss, http_req, jwt, 0);
+    if (stir_shaken_zstr(http_req->url)) {
+        stir_shaken_set_error(ss, "URL missing", STIR_SHAKEN_ERROR_GENERAL);
+        return STIR_SHAKEN_STATUS_TERM;
+    }
 
-#if STIR_SHAKEN_MOCK_ACME_CERT_REQ
-	// Mock response
-	ss_status = STIR_SHAKEN_STATUS_OK;
-	stir_shaken_as_acme_mock_cert_req_response(as, &http_req);
-#endif
+    if (stir_shaken_zstr(spc)) {
+        stir_shaken_set_error(ss, "SPC missing", STIR_SHAKEN_ERROR_GENERAL);
+        return STIR_SHAKEN_STATUS_TERM;
+    }
+    snprintf(cert_download_url, STIR_SHAKEN_BUFLEN, "%s/%s", http_req->url, spc);
 
-	if (ss_status != STIR_SHAKEN_STATUS_OK) {
-		goto exit;
-	}
+    if (stir_shaken_zstr(jwt)) {
+        stir_shaken_set_error(ss, "JWT missing", STIR_SHAKEN_ERROR_GENERAL);
+        return STIR_SHAKEN_STATUS_TERM;
+    }
 
-	if (http_req->response.code != 200 && http_req->response.code != 201) {
-		stir_shaken_set_error(ss, http_req->response.error, STIR_SHAKEN_ERROR_ACME);
-		ss_status = STIR_SHAKEN_STATUS_FALSE;
-		goto exit;
-	}
+    if (!key) {
+        stir_shaken_set_error(ss, "Key not set", STIR_SHAKEN_ERROR_GENERAL);
+        return STIR_SHAKEN_STATUS_TERM;
+    }
 
-	/**
-	 * Process response to cert req, performing authorization if required by STI-CA.
-	 * Authorization is performed by responding to the challenge with the current SP Code Token.
-	 * Performing Steps 4, 5, 7 of 6.3.5.2 ACME Based Steps for Application for an STI Certificate [ATIS-1000080].
-	 */
+    if (keylen < 1) {
+        stir_shaken_set_error(ss, "Invalid key. Key length must be > 0", STIR_SHAKEN_ERROR_GENERAL);
+        return STIR_SHAKEN_STATUS_TERM;
+    }
 
-	ss_status = stir_shaken_acme_perform_authorization(ss, http_req->response.mem.mem, spc_token, key, keylen, http_req->remote_port);
-	if (ss_status != STIR_SHAKEN_STATUS_OK) {
-		stir_shaken_set_error(ss, "ACME failed at authorization step", STIR_SHAKEN_ERROR_ACME);
-		goto exit;
-	}
+    if (stir_shaken_zstr(spc_token)) {
+        stir_shaken_set_error(ss, "SPC token missing", STIR_SHAKEN_ERROR_GENERAL);
+        return STIR_SHAKEN_STATUS_TERM;
+    }
 
-	/*
-	 * Download cert.
-	 * Executing 6.3.6 STI Certificate Acquisition [ATIS-1000080].
-	 */
+    /**
+     * Make cert req.
+     * Performing Step 1 of 6.3.5.2 ACME Based Steps for Application for an STI Certificate [ATIS-1000080].
+     */
 
-	stir_shaken_destroy_http_request(http_req);
+    http_req->action = STIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_INIT;
+    ss_status = stir_shaken_make_http_post_req(ss, http_req, jwt, 0);
 
-	http_req->url = strdup(cert_download_url);
+    if (ss_status != STIR_SHAKEN_STATUS_OK) {
+        goto exit;
+    }
+
+    if (http_req->response.code != 200 && http_req->response.code != 201) {
+        stir_shaken_set_error(ss, http_req->response.error, STIR_SHAKEN_ERROR_ACME);
+        ss_status = STIR_SHAKEN_STATUS_FALSE;
+        goto exit;
+    }
+
+    /**
+     * Process response to cert req, performing authorization if required by STI-CA.
+     * Authorization is performed by responding to the challenge with the current SP Code Token.
+     * Performing Steps 4, 5, 7 of 6.3.5.2 ACME Based Steps for Application for an STI Certificate [ATIS-1000080].
+     */
+
+    ss_status = stir_shaken_acme_perform_authorization(ss, http_req->response.mem.mem, spc_token, key, keylen, http_req->remote_port);
+    if (ss_status != STIR_SHAKEN_STATUS_OK) {
+        stir_shaken_set_error(ss, "ACME failed at authorization step", STIR_SHAKEN_ERROR_ACME);
+        goto exit;
+    }
+
+    /*
+     * Download cert.
+     * Executing 6.3.6 STI Certificate Acquisition [ATIS-1000080].
+     */
+
+    stir_shaken_destroy_http_request(http_req);
+
+    http_req->url = strdup(cert_download_url);
     http_req->remote_port = remote_port;
-	ss_status = stir_shaken_download_cert(ss, http_req);
-	if (ss_status != STIR_SHAKEN_STATUS_OK) {
-		stir_shaken_set_error(ss, "ACME failed to download certificate", STIR_SHAKEN_ERROR_ACME);
-		goto exit;
-	}
+    http_req->action = STIR_SHAKEN_ACTION_TYPE_SP_CERT_DOWNLOAD;
 
-	return STIR_SHAKEN_STATUS_OK;
+    ss_status = stir_shaken_download_cert(ss, http_req);
+    if (ss_status != STIR_SHAKEN_STATUS_OK) {
+        stir_shaken_set_error(ss, "ACME failed to download certificate", STIR_SHAKEN_ERROR_ACME);
+        goto exit;
+    }
+
+    return STIR_SHAKEN_STATUS_OK;
 
 
 exit:
 
-	stir_shaken_set_error_if_clear(ss, "ACME failed to download certificate", STIR_SHAKEN_ERROR_ACME);
-	stir_shaken_destroy_http_request(http_req);
-	return ss_status;
+    stir_shaken_set_error_if_clear(ss, "ACME failed to download certificate", STIR_SHAKEN_ERROR_ACME);
+    stir_shaken_destroy_http_request(http_req);
+    return ss_status;
 }
 
 stir_shaken_status_t stir_shaken_sp_cert_req_ex(stir_shaken_context_t *ss, stir_shaken_http_req_t *http_req, const char *kid, const char *nonce, X509_REQ *req, const char *nb, const char *na, const char *spc, unsigned char *key, uint32_t keylen, char **json, char *spc_token)
 {
     stir_shaken_status_t	ss_status = STIR_SHAKEN_STATUS_FALSE;
-	char					*jwt_encoded = NULL;
-	char					*jwt_decoded = NULL;
+    char					*jwt_encoded = NULL;
+    char					*jwt_decoded = NULL;
 
 
-	if (!req) {
-		stir_shaken_set_error(ss, "X509 REQ missing", STIR_SHAKEN_ERROR_GENERAL);
-		return STIR_SHAKEN_STATUS_TERM;
-	}
+    if (!req) {
+        stir_shaken_set_error(ss, "X509 REQ missing", STIR_SHAKEN_ERROR_GENERAL);
+        return STIR_SHAKEN_STATUS_TERM;
+    }
 
-	if (stir_shaken_zstr(nonce)) {
-		// Allow for empty nonce for now
-		//stir_shaken_set_error(ss, "Nonce missing", STIR_SHAKEN_ERROR_GENERAL);
-	}
+    if (stir_shaken_zstr(nonce)) {
+        // Allow for empty nonce for now
+        //stir_shaken_set_error(ss, "Nonce missing", STIR_SHAKEN_ERROR_GENERAL);
+    }
 
-	if (!key) {
-		stir_shaken_set_error(ss, "Key not set", STIR_SHAKEN_ERROR_GENERAL);
-		return STIR_SHAKEN_STATUS_TERM;
-	}
-	
-	if (keylen < 1) {
-		stir_shaken_set_error(ss, "Invalid key. Key length must be > 0", STIR_SHAKEN_ERROR_GENERAL);
-		return STIR_SHAKEN_STATUS_TERM;
-	}
-	
-	if (stir_shaken_zstr(spc)) {
-		stir_shaken_set_error(ss, "SPC missing", STIR_SHAKEN_ERROR_GENERAL);
-		return STIR_SHAKEN_STATUS_TERM;
-	}
-	
-	jwt_encoded = stir_shaken_acme_generate_cert_req_payload(ss, kid, nonce, http_req->url, req, nb, na, spc, key, keylen, &jwt_decoded);
-	if (!jwt_encoded || !jwt_decoded) {
-		stir_shaken_set_error(ss, "Failed to generate JWT payload", STIR_SHAKEN_ERROR_JWT);
-		return STIR_SHAKEN_STATUS_TERM;
-	}
+    if (!key) {
+        stir_shaken_set_error(ss, "Key not set", STIR_SHAKEN_ERROR_GENERAL);
+        return STIR_SHAKEN_STATUS_TERM;
+    }
 
-	ss_status = stir_shaken_sp_cert_req(ss, http_req, jwt_encoded, key, keylen, spc, spc_token);
+    if (keylen < 1) {
+        stir_shaken_set_error(ss, "Invalid key. Key length must be > 0", STIR_SHAKEN_ERROR_GENERAL);
+        return STIR_SHAKEN_STATUS_TERM;
+    }
+
+    if (stir_shaken_zstr(spc)) {
+        stir_shaken_set_error(ss, "SPC missing", STIR_SHAKEN_ERROR_GENERAL);
+        return STIR_SHAKEN_STATUS_TERM;
+    }
+
+    jwt_encoded = stir_shaken_acme_generate_cert_req_payload(ss, kid, nonce, http_req->url, req, nb, na, spc, key, keylen, &jwt_decoded);
+    if (!jwt_encoded || !jwt_decoded) {
+        stir_shaken_set_error(ss, "Failed to generate JWT payload", STIR_SHAKEN_ERROR_JWT);
+        return STIR_SHAKEN_STATUS_TERM;
+    }
+
+    ss_status = stir_shaken_sp_cert_req(ss, http_req, jwt_encoded, key, keylen, spc, spc_token);
 
 #if STIR_SHAKEN_MOCK_ACME_CERT_REQ
-	// Mock response
-	ss_status = STIR_SHAKEN_STATUS_OK;
-	stir_shaken_as_acme_mock_cert_req_response(as, &http_req);
+    // Mock response
+    ss_status = STIR_SHAKEN_STATUS_OK;
+    stir_shaken_as_acme_mock_cert_req_response(as, &http_req);
 #endif
 
-	if (ss_status != STIR_SHAKEN_STATUS_OK) {
-		goto exit;
-	}
+    if (ss_status != STIR_SHAKEN_STATUS_OK) {
+        goto exit;
+    }
 
-	if (http_req->response.code != 200 && http_req->response.code != 201) {
-		stir_shaken_set_error(ss, http_req->response.error, STIR_SHAKEN_ERROR_ACME);
-		ss_status = STIR_SHAKEN_STATUS_FALSE;
-		goto exit;
-	}
+    if (http_req->response.code != 200 && http_req->response.code != 201) {
+        stir_shaken_set_error(ss, http_req->response.error, STIR_SHAKEN_ERROR_ACME);
+        ss_status = STIR_SHAKEN_STATUS_FALSE;
+        goto exit;
+    }
 
-	if (stir_shaken_zstr(http_req->response.mem.mem)) {
-		stir_shaken_set_error(ss, "Got empty response from CA", STIR_SHAKEN_ERROR_ACME_EMPTY_CA_RESPONSE);
-		ss_status = STIR_SHAKEN_STATUS_FALSE;
-		goto exit;
-	}
+    if (stir_shaken_zstr(http_req->response.mem.mem)) {
+        stir_shaken_set_error(ss, "Got empty response from CA", STIR_SHAKEN_ERROR_ACME_EMPTY_CA_RESPONSE);
+        ss_status = STIR_SHAKEN_STATUS_FALSE;
+        goto exit;
+    }
 
-	fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "-> Got STI certificate from CA:\n%s\n", http_req->response.mem.mem);
+    fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "-> Got STI certificate from CA:\n%s\n", http_req->response.mem.mem);
 
-	if (json) {
-		*json = jwt_decoded;
-	} else {
-		stir_shaken_free_jwt_str(jwt_decoded);
-	}
-	stir_shaken_free_jwt_str(jwt_encoded);
-	return STIR_SHAKEN_STATUS_OK;
+    if (json) {
+        *json = jwt_decoded;
+    } else {
+        stir_shaken_free_jwt_str(jwt_decoded);
+    }
+    stir_shaken_free_jwt_str(jwt_encoded);
+    return STIR_SHAKEN_STATUS_OK;
 
 
 exit:
 
-	stir_shaken_set_error_if_clear(ss, "ACME failed to download certificate", STIR_SHAKEN_ERROR_ACME);
-	stir_shaken_destroy_http_request(http_req);
-	if (jwt_encoded) stir_shaken_free_jwt_str(jwt_encoded);
-	if (jwt_decoded) stir_shaken_free_jwt_str(jwt_decoded);
-	return ss_status;
+    stir_shaken_set_error_if_clear(ss, "ACME failed to download certificate", STIR_SHAKEN_ERROR_ACME);
+    stir_shaken_destroy_http_request(http_req);
+    if (jwt_encoded) stir_shaken_free_jwt_str(jwt_encoded);
+    if (jwt_decoded) stir_shaken_free_jwt_str(jwt_decoded);
+    return ss_status;
 }
 
 void stir_shaken_sp_destroy(stir_shaken_sp_t *sp)
 {
-	if (sp) {
-		stir_shaken_destroy_csr(&sp->csr);
-		stir_shaken_destroy_cert(&sp->cert);
-		stir_shaken_destroy_keys(&sp->keys);
-		if (sp->kid) free(sp->kid);
-		if (sp->nonce) free(sp->nonce);
-		if (sp->nb) free(sp->nb);
-		if (sp->na) free(sp->na);
-		memset(sp, 0, sizeof(*sp));
-	}
+    if (sp) {
+        stir_shaken_destroy_csr(&sp->csr);
+        stir_shaken_destroy_cert(&sp->cert);
+        stir_shaken_destroy_keys(&sp->keys);
+        if (sp->kid) free(sp->kid);
+        if (sp->nonce) free(sp->nonce);
+        if (sp->nb) free(sp->nb);
+        if (sp->na) free(sp->na);
+        memset(sp, 0, sizeof(*sp));
+    }
 }

--- a/src/stir_shaken_verify.c
+++ b/src/stir_shaken_verify.c
@@ -128,7 +128,7 @@ static size_t curl_callback(void *contents, size_t size, size_t nmemb, void *p)
     return realsize;
 }
 
-stir_shaken_status_t stir_shaken_download_cert(stir_shaken_context_t *ss, stir_shaken_http_req_t *http_req)
+stir_shaken_status_t stir_shaken_sih_verify_with_cert(stir_shaken_context_t *ss, const char *identity_header, stir_shaken_cert_t *cert, stir_shaken_passport_t *passport)
 {
     stir_shaken_status_t ss_status = STIR_SHAKEN_STATUS_FALSE;
 
@@ -519,16 +519,16 @@ stir_shaken_status_t stir_shaken_sih_verify(stir_shaken_context_t *ss, const cha
     stir_shaken_clear_error(ss);
     memset(&http_req, 0, sizeof(http_req));
 
-
-    if (!sih) {
-        stir_shaken_set_error(ss, "SIP Identity Header not set", STIR_SHAKEN_ERROR_SIP_438_INVALID_IDENTITY_HEADER);
-        goto end;
-    }
-
-    if (!passport) {
-        stir_shaken_set_error(ss, "PASSporT not set", STIR_SHAKEN_ERROR_GENERAL);
-        goto end;
-    }
+	
+	if (!sih) {
+		stir_shaken_set_error(ss, "SIP Identity Header not set", STIR_SHAKEN_ERROR_SIP_438_INVALID_IDENTITY_HEADER);
+		goto end;
+	}
+	
+	if (!passport) {
+		stir_shaken_set_error(ss, "PASSporT not set", STIR_SHAKEN_ERROR_GENERAL);
+		goto end;
+	}
 
     ss_status = stir_shaken_jwt_sih_to_jwt_encoded(ss, sih, &jwt_encoded[0], STIR_SHAKEN_PUB_KEY_RAW_BUF_LEN);
     if (ss_status != STIR_SHAKEN_STATUS_OK) {

--- a/src/stir_shaken_verify.c
+++ b/src/stir_shaken_verify.c
@@ -128,7 +128,7 @@ static size_t curl_callback(void *contents, size_t size, size_t nmemb, void *p)
     return realsize;
 }
 
-stir_shaken_status_t stir_shaken_sih_verify_with_cert(stir_shaken_context_t *ss, const char *identity_header, stir_shaken_cert_t *cert, stir_shaken_passport_t *passport)
+stir_shaken_status_t stir_shaken_download_cert(stir_shaken_context_t *ss, stir_shaken_http_req_t *http_req)
 {
     stir_shaken_status_t ss_status = STIR_SHAKEN_STATUS_FALSE;
 
@@ -177,11 +177,6 @@ stir_shaken_status_t stir_shaken_jwt_download_cert(stir_shaken_context_t *ss, co
 
     if (!cert_out) {
         stir_shaken_set_error(ss, "Bad params: Pointer to result cert is NULL", STIR_SHAKEN_ERROR_SIP_436_BAD_IDENTITY_INFO);
-        goto fail;
-    }
-
-    if (jwt_new(&jwt) != 0) {
-        stir_shaken_set_error(ss, "Cannot create JWT for the token", STIR_SHAKEN_ERROR_JWT);
         goto fail;
     }
 

--- a/test/stir_shaken_test_13.c
+++ b/test/stir_shaken_test_13.c
@@ -1,9 +1,7 @@
 #include <stir_shaken.h>
 
-
 const char *path = "./test/run";
 
-stir_shaken_sp_t sp;
 
 #define PRINT_SHAKEN_ERROR_IF_SET \
     if (stir_shaken_is_error_set(&ss)) { \
@@ -12,7 +10,7 @@ stir_shaken_sp_t sp;
         printf("Error code is: '%d'\n", error_code); \
     }
 
-stir_shaken_status_t stir_shaken_unit_test_sp_cert_req(void)
+stir_shaken_status_t stir_shaken_unit_test_hash(void)
 {
     EVP_PKEY *pkey = NULL;
     stir_shaken_status_t status = STIR_SHAKEN_STATUS_FALSE;
@@ -117,7 +115,7 @@ stir_shaken_status_t stir_shaken_unit_test_sp_cert_req(void)
     return STIR_SHAKEN_STATUS_OK;
 }
 
-int main(void)
+int main(int argc, char ** argv)
 {
     stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_do_init(NULL, NULL, NULL, STIR_SHAKEN_LOGLEVEL_HIGH), "Cannot init lib");
 

--- a/test/stir_shaken_test_13.c
+++ b/test/stir_shaken_test_13.c
@@ -10,7 +10,9 @@ const char *path = "./test/run";
         printf("Error code is: '%d'\n", error_code); \
     }
 
-stir_shaken_status_t stir_shaken_unit_test_hash(void)
+stir_shaken_sp_t sp;
+
+stir_shaken_status_t stir_shaken_unit_test_sp_cert_req(void)
 {
     EVP_PKEY *pkey = NULL;
     stir_shaken_status_t status = STIR_SHAKEN_STATUS_FALSE;

--- a/test/stir_shaken_test_14.c
+++ b/test/stir_shaken_test_14.c
@@ -1,7 +1,12 @@
-#include <stir_shaken.h>
+#include "../include/stir_shaken.h"
 
 const char *path = "./test/run";
 
+#define CA_DIR	"./test/run/ca"
+#define CRL_DIR	"./test/run/crl"
+
+stir_shaken_ca_t ca;
+stir_shaken_sp_t sp;
 
 #define PRINT_SHAKEN_ERROR_IF_SET \
 	if (stir_shaken_is_error_set(&ss)) { \
@@ -10,165 +15,182 @@ const char *path = "./test/run";
 		printf("Error code is: '%d'\n", error_code); \
 	}
 
-void funny_and_useless(void *o)
+stir_shaken_status_t stir_shaken_unit_test_x509_cert_path_verification(void)
 {
-	fprintf(stderr, "Funny and useless destructor ;~)\n");
-}
-
-stir_shaken_status_t stir_shaken_unit_test_hash(void)
-{
+	EVP_PKEY *pkey = NULL;
 	stir_shaken_status_t status = STIR_SHAKEN_STATUS_FALSE;
 	stir_shaken_context_t ss = { 0 };
 	const char *error_description = NULL;
 	stir_shaken_error_t error_code = STIR_SHAKEN_ERROR_GENERAL;
-	stir_shaken_hash_entry_t* sessions[STI_CA_SESSIONS_MAX] = { 0 }, *e = NULL;
-	size_t spc = 0;
+	unsigned long hash = 0;
+	char hashstr[100] = { 0 };
+	int hashstrlen = 100;
 
-	spc = 0;
-	e = stir_shaken_hash_entry_find(sessions, STI_CA_SESSIONS_MAX, spc);
-	stir_shaken_assert(e == NULL, "Err, entry should not be found...");
-	
-	spc = 1;
-	e = stir_shaken_hash_entry_find(sessions, STI_CA_SESSIONS_MAX, spc);
-	stir_shaken_assert(e == NULL, "Err, entry should not be found...");
-	
-	spc = 12;
-	e = stir_shaken_hash_entry_find(sessions, STI_CA_SESSIONS_MAX, spc);
-	stir_shaken_assert(e == NULL, "Err, entry should not be found...");
 
-	spc = 133;
-	e = stir_shaken_hash_entry_find(sessions, STI_CA_SESSIONS_MAX, spc);
-	stir_shaken_assert(e == NULL, "Err, entry should not be found...");
-	
-	spc = 500;
-	e = stir_shaken_hash_entry_find(sessions, STI_CA_SESSIONS_MAX, spc);
-	stir_shaken_assert(e == NULL, "Err, entry should not be found...");
-	
-	spc = 1234;
-	e = stir_shaken_hash_entry_find(sessions, STI_CA_SESSIONS_MAX, spc);
-	stir_shaken_assert(e == NULL, "Err, entry should not be found...");
-	
-	spc = 7777;
-	e = stir_shaken_hash_entry_find(sessions, STI_CA_SESSIONS_MAX, spc);
-	stir_shaken_assert(e == NULL, "Err, entry should not be found...");
-	
-	spc = 10000;
-	e = stir_shaken_hash_entry_find(sessions, STI_CA_SESSIONS_MAX, spc);
-	stir_shaken_assert(e == NULL, "Err, entry should not be found...");
-	
-	spc = 0;
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK != stir_shaken_hash_entry_remove(sessions, STI_CA_SESSIONS_MAX, spc, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry should not be removed...");
-	
-	spc = 1;
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK != stir_shaken_hash_entry_remove(sessions, STI_CA_SESSIONS_MAX, spc, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry should not be removed...");
-	
-	spc = 12;
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK != stir_shaken_hash_entry_remove(sessions, STI_CA_SESSIONS_MAX, spc, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry should not be removed...");
-	
-	spc = 133;
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK != stir_shaken_hash_entry_remove(sessions, STI_CA_SESSIONS_MAX, spc, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry should not be removed...");
-	
-	spc = 500;
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK != stir_shaken_hash_entry_remove(sessions, STI_CA_SESSIONS_MAX, spc, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry should not be removed...");
-	
-	spc = 1234;
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK != stir_shaken_hash_entry_remove(sessions, STI_CA_SESSIONS_MAX, spc, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry should not be removed...");
-	
-	spc = 7777;
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK != stir_shaken_hash_entry_remove(sessions, STI_CA_SESSIONS_MAX, spc, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry should not be removed...");
-	
-	spc = 10000;
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK != stir_shaken_hash_entry_remove(sessions, STI_CA_SESSIONS_MAX, spc, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry should not be removed...");
-	
-	spc = 0;
-	stir_shaken_assert(NULL != stir_shaken_hash_entry_add(sessions, STI_CA_SESSIONS_MAX, spc, calloc(1, 10), 10, funny_and_useless, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry not added...");
-	
-	spc = 1;
-	stir_shaken_assert(NULL != stir_shaken_hash_entry_add(sessions, STI_CA_SESSIONS_MAX, spc, calloc(1, 10), 10, funny_and_useless, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry not added...");
-	
-	spc = 12;
-	stir_shaken_assert(NULL != stir_shaken_hash_entry_add(sessions, STI_CA_SESSIONS_MAX, spc, calloc(1, 10), 10, funny_and_useless, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry not added...");
-	
-	spc = 133;
-	stir_shaken_assert(NULL != stir_shaken_hash_entry_add(sessions, STI_CA_SESSIONS_MAX, spc, calloc(1, 10), 10, funny_and_useless, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry not added...");
+	sprintf(ca.private_key_name, "%s%c%s", path, '/', "12_ca_private_key.pem");
+	sprintf(ca.public_key_name, "%s%c%s", path, '/', "12_ca_public_key.pem");
+	sprintf(ca.cert_name, "%s%c%s", path, '/', "12_ca_cert.crt");
 
-	spc = 500;
-	stir_shaken_assert(NULL != stir_shaken_hash_entry_add(sessions, STI_CA_SESSIONS_MAX, spc, calloc(1, 10), 10, funny_and_useless, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry not added...");
-	
-	spc = 1234;
-	stir_shaken_assert(NULL != stir_shaken_hash_entry_add(sessions, STI_CA_SESSIONS_MAX, spc, calloc(1, 10), 10, funny_and_useless, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry not added...");
-	
-	spc = 7777;
-	stir_shaken_assert(NULL != stir_shaken_hash_entry_add(sessions, STI_CA_SESSIONS_MAX, spc, calloc(1, 10), 10, funny_and_useless, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry not added...");
-	
-	spc = 10000;
-	stir_shaken_assert(NULL != stir_shaken_hash_entry_add(sessions, STI_CA_SESSIONS_MAX, spc, calloc(1, 10), 10, funny_and_useless, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry not added...");
-	
-	spc = 0;
-	e = stir_shaken_hash_entry_find(sessions, STI_CA_SESSIONS_MAX, spc);
-	stir_shaken_assert(e != NULL, "Err, entry should be found...");
-	
-	spc = 1;
-	e = stir_shaken_hash_entry_find(sessions, STI_CA_SESSIONS_MAX, spc);
-	stir_shaken_assert(e != NULL, "Err, entry should be found...");
-	
-	spc = 12;
-	e = stir_shaken_hash_entry_find(sessions, STI_CA_SESSIONS_MAX, spc);
-	stir_shaken_assert(e != NULL, "Err, entry should be found...");
+	sprintf(sp.private_key_name, "%s%c%s", path, '/', "12_sp_private_key.pem");
+	sprintf(sp.public_key_name, "%s%c%s", path, '/', "12_sp_public_key.pem");
+	sprintf(sp.csr_name, "%s%c%s", path, '/', "12_sp_csr.pem");
+	sprintf(sp.cert_name, "%s%c%s", path, '/', "12_sp_cert.crt");
 
-	spc = 133;
-	e = stir_shaken_hash_entry_find(sessions, STI_CA_SESSIONS_MAX, spc);
-	stir_shaken_assert(e != NULL, "Err, entry should be found...");
-	
-	spc = 500;
-	e = stir_shaken_hash_entry_find(sessions, STI_CA_SESSIONS_MAX, spc);
-	stir_shaken_assert(e != NULL, "Err, entry should be found...");
-	
-	spc = 1234;
-	e = stir_shaken_hash_entry_find(sessions, STI_CA_SESSIONS_MAX, spc);
-	stir_shaken_assert(e != NULL, "Err, entry should be found...");
-	
-	spc = 7777;
-	e = stir_shaken_hash_entry_find(sessions, STI_CA_SESSIONS_MAX, spc);
-	stir_shaken_assert(e != NULL, "Err, entry should be found...");
-	
-	spc = 10000;
-	e = stir_shaken_hash_entry_find(sessions, STI_CA_SESSIONS_MAX, spc);
-	stir_shaken_assert(e != NULL, "Err, entry should be found...");
-	
-	spc = 0;
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_hash_entry_remove(sessions, STI_CA_SESSIONS_MAX, spc, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry should be removed...");
-	
-	spc = 1;
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_hash_entry_remove(sessions, STI_CA_SESSIONS_MAX, spc, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry should be removed...");
-	
-	spc = 12;
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_hash_entry_remove(sessions, STI_CA_SESSIONS_MAX, spc, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry should be removed...");
-	
-	spc = 133;
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_hash_entry_remove(sessions, STI_CA_SESSIONS_MAX, spc, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry should be removed...");
-	
-	spc = 500;
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_hash_entry_remove(sessions, STI_CA_SESSIONS_MAX, spc, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry should be removed...");
-	
-	spc = 1234;
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_hash_entry_remove(sessions, STI_CA_SESSIONS_MAX, spc, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry should be removed...");
-	
-	spc = 7777;
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_hash_entry_remove(sessions, STI_CA_SESSIONS_MAX, spc, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry should be removed...");
-	
-	spc = 10000;
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_hash_entry_remove(sessions, STI_CA_SESSIONS_MAX, spc, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE), "Err, entry should be removed...");
+	printf("=== Unit testing: STIR/Shaken X509 cert path verification [stir_shaken_unit_test_x509_cert_path_verification]\n\n");
 
-	// cleanup
-	stir_shaken_hash_destroy(sessions, STI_CA_SESSIONS_MAX, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE);	
+	printf("CA: Generate CA keys\n");
 
-	return STIR_SHAKEN_STATUS_OK;
+	// Generate CA keys
+	ca.keys.priv_raw_len = STIR_SHAKEN_PRIV_KEY_RAW_BUF_LEN;
+	status = stir_shaken_generate_keys(&ss, &ca.keys.ec_key, &ca.keys.private_key, &ca.keys.public_key, ca.private_key_name, ca.public_key_name, ca.keys.priv_raw, &ca.keys.priv_raw_len);
+	PRINT_SHAKEN_ERROR_IF_SET
+		stir_shaken_assert(status == STIR_SHAKEN_STATUS_OK, "Err, failed to generate keys...");
+	stir_shaken_assert(ca.keys.ec_key != NULL, "Err, failed to generate EC key\n\n");
+	stir_shaken_assert(ca.keys.private_key != NULL, "Err, failed to generate private key");
+	stir_shaken_assert(ca.keys.public_key != NULL, "Err, failed to generate public key");
+
+	// 1
+	// SP obtains SPC and SPC token from PA and can now construct CSR
+
+	printf("SP: Generate SP keys\n");
+
+	// Generate SP keys
+	sp.keys.priv_raw_len = STIR_SHAKEN_PRIV_KEY_RAW_BUF_LEN;
+	status = stir_shaken_generate_keys(&ss, &sp.keys.ec_key, &sp.keys.private_key, &sp.keys.public_key, sp.private_key_name, sp.public_key_name, sp.keys.priv_raw, &sp.keys.priv_raw_len);
+	PRINT_SHAKEN_ERROR_IF_SET
+		stir_shaken_assert(status == STIR_SHAKEN_STATUS_OK, "Err, failed to generate keys...");
+	stir_shaken_assert(sp.keys.ec_key != NULL, "Err, failed to generate EC key\n\n");
+	stir_shaken_assert(sp.keys.private_key != NULL, "Err, failed to generate private key");
+	stir_shaken_assert(sp.keys.public_key != NULL, "Err, failed to generate public key");
+
+	printf("SP: Create CSR\n");
+	sp.code = 7777;
+	snprintf(sp.subject_c, STIR_SHAKEN_BUFLEN, "US");
+	snprintf(sp.subject_cn, STIR_SHAKEN_BUFLEN, "NewSTI-SP, But Absolutely Fine Inc.");
+
+	status = stir_shaken_generate_csr(&ss, sp.code, &sp.csr.req, sp.keys.private_key, sp.keys.public_key, sp.subject_c, sp.subject_cn);
+	PRINT_SHAKEN_ERROR_IF_SET
+	stir_shaken_assert(status == STIR_SHAKEN_STATUS_OK, "Err, generating CSR");
+
+	// 2
+	// CA creates self-signed cert
+
+	printf("CA: Create self-signed CA Certificate\n");
+
+	snprintf(ca.issuer_c, STIR_SHAKEN_BUFLEN, "US");
+	snprintf(ca.issuer_cn, STIR_SHAKEN_BUFLEN, "SignalWire Secure");
+	ca.serial = 1;
+	ca.expiry_days = 90;
+	ca.cert.x = stir_shaken_generate_x509_self_signed_ca_cert(&ss, ca.keys.private_key, ca.keys.public_key, ca.issuer_c, ca.issuer_cn, ca.serial, ca.expiry_days);
+	PRINT_SHAKEN_ERROR_IF_SET
+		stir_shaken_assert(ca.cert.x, "Err, generating CA cert");
+
+
+	// 3
+	// SP sends CSR to CA
+
+	// 4
+	// CA challanges SP with TNAuthList challenge
+
+	// 5
+	// SP responds with SPC token
+
+	// 6
+	// CA can generate cert for SP now
+	printf("CA: Create end-entity SP Certificate from SP's CSR\n");
+	snprintf(ca.tn_auth_list_uri, STIR_SHAKEN_BUFLEN, "http://ca.com/api");
+	//sp.cert.x = stir_shaken_generate_x509_cert_from_csr(&ss, sp.code, sp.csr.req, ca.keys.private_key, ca.issuer_c, ca.issuer_cn, sp.serial, sp.expiry_days);
+	pkey = X509_REQ_get_pubkey(sp.csr.req);
+	stir_shaken_assert(1 == EVP_PKEY_cmp(pkey, sp.keys.public_key), "Public key in CSR different than SP's");
+	//sp.cert.x = stir_shaken_generate_x509_end_entity_cert(&ss, ca.cert.x, ca.keys.private_key, sp.keys.public_key, ca.issuer_c, ca.issuer_cn, sp.subject_c, sp.subject_cn, ca.serial_sp, ca.expiry_days_sp, ca.number_start_sp, ca.number_end_sp);
+	sp.cert.x = stir_shaken_generate_x509_end_entity_cert_from_csr(&ss, ca.cert.x, ca.keys.private_key, ca.issuer_c, ca.issuer_cn, sp.csr.req, ca.serial, ca.expiry_days, ca.tn_auth_list_uri);
+	PRINT_SHAKEN_ERROR_IF_SET
+    stir_shaken_assert(sp.cert.x != NULL, "Err, generating Cert");
+
+	// SAVE CSR and certificates
+
+	if (STIR_SHAKEN_STATUS_OK != stir_shaken_csr_to_disk(&ss, sp.csr.req, sp.csr_name)) {
+		printf("STIR-Shaken: Failed to write CSR to disk\n");
+		PRINT_SHAKEN_ERROR_IF_SET
+			return STIR_SHAKEN_STATUS_TERM;
+	}
+
+	if (STIR_SHAKEN_STATUS_OK != stir_shaken_x509_to_disk(&ss, ca.cert.x, ca.cert_name)) {
+		printf("Failed to write CA certificate to disk\n");
+		PRINT_SHAKEN_ERROR_IF_SET
+			return STIR_SHAKEN_STATUS_TERM;
+	}
+
+	if (STIR_SHAKEN_STATUS_OK != stir_shaken_x509_to_disk(&ss, sp.cert.x, sp.cert_name)) {
+		printf("Failed to write SP certificate to disk\n");
+		PRINT_SHAKEN_ERROR_IF_SET
+			return STIR_SHAKEN_STATUS_TERM;
+	}
+
+	/* Test */
+	printf("TEST: verifying end-entity + CA combo cert with X509 cert path verification...\n\n");
+
+	printf("TEST 1: Checking if X509_verify_cert returns error for SP cert\n");
+	status = stir_shaken_verify_cert(&ss, &sp.cert);
+	if (STIR_SHAKEN_STATUS_OK != status) {
+		printf("X509 cert path verification correctly failed, no CA cert in CA dir yet...\n");
+		PRINT_SHAKEN_ERROR_IF_SET
+	}
+	stir_shaken_assert(STIR_SHAKEN_STATUS_OK != status, "Error, status should NOT be OK");
+
+	// Add CA cert to CA dir, as trusted anchor
+	// Must be in hash.N form for X509_verify_cert to recognize it
+	hash = stir_shaken_get_cert_name_hashed(&ss, ca.cert.x);
+	if (hash == 0) {
+		printf("Failed to get CA cert name hashed\n");
+		PRINT_SHAKEN_ERROR_IF_SET
+			return STIR_SHAKEN_STATUS_TERM;
+	}
+	printf("CA name hash is %lu\n", hash);
+
+	stir_shaken_cert_name_hashed_2_string(hash, hashstr, hashstrlen);
+
+	sprintf(ca.cert_name_hashed, "./test/run/ca/%s.0", hashstr);
+	printf("Adding CA cert to CA dir as %s\n", ca.cert_name_hashed);
+
+	if (STIR_SHAKEN_STATUS_OK != stir_shaken_x509_to_disk(&ss, ca.cert.x, ca.cert_name_hashed)) {
+		printf("Failed to write CA certificate to CA dir\n");
+		PRINT_SHAKEN_ERROR_IF_SET
+			return STIR_SHAKEN_STATUS_TERM;
+	}
+
+	printf("Reinitialising X509 cert store...\n");
+	// Must reinitialize now X509 cert store
+	if (STIR_SHAKEN_STATUS_OK != stir_shaken_init_cert_store(&ss, NULL, CA_DIR, NULL, NULL)) {
+		printf("Failed to re-init CA dir\n");
+		PRINT_SHAKEN_ERROR_IF_SET
+			return STIR_SHAKEN_STATUS_TERM;
+	}
+
+	printf("TEST 2: Checking if X509_verify_cert returns SUCCESS for SP cert\n");
+	// Now it should work
+	status = stir_shaken_verify_cert(&ss, &sp.cert);
+	if (STIR_SHAKEN_STATUS_OK != status) {
+		printf("X509 cert path verification failed for SP certificate\n");
+		PRINT_SHAKEN_ERROR_IF_SET
+	}
+	stir_shaken_assert(STIR_SHAKEN_STATUS_OK == status, "Error, status should be OK");
+
+	// CA cleanup	
+	stir_shaken_destroy_cert(&ca.cert);
+	stir_shaken_destroy_keys_ex(&ca.keys.ec_key, &ca.keys.private_key, &ca.keys.public_key);
+
+	// SP cleanup	
+	stir_shaken_sp_destroy(&sp);
+
+	EVP_PKEY_free(pkey);
+
+	return status;
 }
 
 int main(void)
 {
-	stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_do_init(NULL, NULL, NULL, STIR_SHAKEN_LOGLEVEL_HIGH), "Cannot init lib");
+	stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_do_init(NULL, CA_DIR, CRL_DIR, STIR_SHAKEN_LOGLEVEL_HIGH), "Cannot init lib");
 
 	if (stir_shaken_dir_exists(path) != STIR_SHAKEN_STATUS_OK) {
 
@@ -179,7 +201,7 @@ int main(void)
 		}
 	}
 
-	if (stir_shaken_unit_test_hash() != STIR_SHAKEN_STATUS_OK) {
+	if (stir_shaken_unit_test_x509_cert_path_verification() != STIR_SHAKEN_STATUS_OK) {
 
 		printf("Fail\n");
 		return -2;

--- a/test/stir_shaken_test_15.c
+++ b/test/stir_shaken_test_15.c
@@ -1,0 +1,538 @@
+#include <stir_shaken.h>
+
+
+const char *path = "./test/run";
+
+stir_shaken_ca_t ca = { .cert_name = "test/ref/ca/ca.pem", .private_key_name = "test/ref/ca/ca.priv", .issuer_c = "US", .issuer_cn = "TEST CA", .serial = 1, .expiry_days = 9999, .tn_auth_list_uri = "https://test-ca.com/auth-list-check" };
+int polling;
+int ca_verifying_spc_token;
+const char *pa_pem = "-----BEGIN CERTIFICATE-----\n"
+"MIIB+jCCAaCgAwIBAgIBATAKBggqhkjOPQQDAjAuMQswCQYDVQQGEwJVUzEfMB0G\n"
+"A1UEAwwWU2lnbmFsV2lyZSBTVEktUEEgVGVzdDAeFw0yMDA4MDEwMDA2NTBaFw00\n"
+"NzEyMTcwMDA2NTBaMC4xCzAJBgNVBAYTAlVTMR8wHQYDVQQDDBZTaWduYWxXaXJl\n"
+"IFNUSS1QQSBUZXN0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDjJOep8dsSCN\n"
+"5Nx3wek851dXIYhoOXWkeEGvPgnTFvHA98febb7wiR5NoqB04oKMR9Z8vrYfpJoz\n"
+"dhZpZEAyMqOBrjCBqzAdBgNVHQ4EFgQUc103mIP3PWbtfyK6nZYCpcTCGRwwHwYD\n"
+"VR0jBBgwFoAUc103mIP3PWbtfyK6nZYCpcTCGRwwNQYJYIZIAYb4QgENBCgWJkFs\n"
+"d2F5cyBsb29rIG9uIHRoZSBicmlnaHQgc2lkZSBvZiBsaWZlMA8GA1UdEwEB/wQF\n"
+"MAMBAf8wDgYDVR0PAQH/BAQDAgEGMBEGCWCGSAGG+EIBAQQEAwICBDAKBggqhkjO\n"
+"PQQDAgNIADBFAiB7ZUl2OWFx4CPSxY1jeS2OK9vgeHvVHx6PszwjzN/QTAIhAOhP\n"
+"hz/OkvF1o6XD3UWw5nOY63rPMDM0iB/GbpbIz+Jw\n"
+"-----END CERTIFICATE-----\n";
+
+stir_shaken_sp_t sp;
+
+#define PRINT_SHAKEN_ERROR_IF_SET \
+    if (stir_shaken_is_error_set(&ss)) { \
+        error_description = stir_shaken_get_error(&ss, &error_code); \
+        printf("Error description is: '%s'\n", error_description); \
+        printf("Error code is: '%d'\n", error_code); \
+    }
+
+/*
+ * Mock HTTP transfers in this test.
+ */
+stir_shaken_status_t stir_shaken_make_http_req_mock(stir_shaken_context_t *ss, stir_shaken_http_req_t *http_req)
+{
+    (void) ss;
+
+    printf("\n\nShakening surprise\n\n");
+    stir_shaken_assert(http_req != NULL, "http_req is NULL!");
+
+    printf("MOCK HTTP response code to 200 OK\n");
+    http_req->response.code = 200;
+
+    if (http_req->response.mem.mem) {
+        free(http_req->response.mem.mem);
+        http_req->response.mem.mem = NULL;
+        http_req->response.mem.size = 0;
+    }
+
+    if (ca_verifying_spc_token) {
+
+        int certlen = 0;
+
+        printf("\n\nSTIR_SHAKEN_ACTION_TYPE_CA_CERT_REQ_PA\n\n");
+
+        free(http_req->response.mem.mem);
+        certlen = strlen(pa_pem);
+        stir_shaken_assert(http_req->response.mem.mem = malloc(certlen + 1), "Malloc failed");
+        memset(http_req->response.mem.mem, 0, certlen + 1);
+        strncpy(http_req->response.mem.mem, pa_pem, certlen);
+        ca_verifying_spc_token = 0;
+        return STIR_SHAKEN_STATUS_OK;
+    }
+
+    switch (http_req->action) {
+
+        case STIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_INIT:
+
+            {
+                char authz_url[STIR_SHAKEN_BUFLEN] = { 0 };
+                char authz_challenge[STIR_SHAKEN_BUFLEN] = { 0 };
+                stir_shaken_ca_session_t *session = NULL;
+                int authzlen = 0;
+
+
+                printf("\n\nSTIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_INIT\n\n");
+
+                stir_shaken_assert(STIR_SHAKEN_STATUS_OK == ca_sp_cert_req_reply_challenge(ss, &ca, (char *) http_req->data, authz_challenge, authz_url, &session), "CA reply to SP cert req failed");
+                stir_shaken_assert(!stir_shaken_zstr(authz_challenge), "Authz challenge not created");
+                stir_shaken_assert(!stir_shaken_zstr(authz_url), "Authz url not created");
+                stir_shaken_assert(session, "CA session not created");
+
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "\t-> (MOCK) Added authorization session to queue\n");
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "\t-> (MOCK) Sending authorization challenge:\n%s\n", authz_challenge);
+
+                free(http_req->response.mem.mem);
+                authzlen = strlen(session->authz_challenge);
+                stir_shaken_assert(http_req->response.mem.mem = malloc(authzlen + 1), "Malloc failed");
+                memset(http_req->response.mem.mem, 0, authzlen + 1);
+                strncpy(http_req->response.mem.mem, authz_challenge, authzlen);
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) HTTP/1.1 201 Created\r\nLocation: %s\r\nContent-Length: %lu\r\nContent-Type: application/json\r\n\r\n%s\r\n\r\n", authz_url, strlen(authz_challenge), authz_challenge);
+
+                session->state = STI_CA_SESSION_STATE_AUTHZ_SENT;
+            }
+            break;
+
+        case STIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_REQ_AUTHZ_DETAILS:
+
+            {
+                char spc[STIR_SHAKEN_BUFLEN] = { 0 };
+                unsigned long long int sp_code = 0;
+                char authz_url[STIR_SHAKEN_BUFLEN] = { 0 };
+                char *authz_challenge_details = NULL;
+                int uri_has_secret = 0;
+                unsigned long long secret = 0;
+                int authz_secret = 0;
+                int authzlen = 0;
+
+                stir_shaken_hash_entry_t *e = NULL;
+                stir_shaken_ca_session_t *session = NULL;
+
+
+                printf("\n\nSTIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_REQ_AUTHZ_DETAILS\n\n");
+
+                stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_acme_api_uri_to_spc(ss, http_req->url, STI_CA_ACME_AUTHZ_URL, spc, STIR_SHAKEN_BUFLEN, &sp_code, &uri_has_secret, &secret), "ACME uri to SPC failed");
+                stir_shaken_assert(!stir_shaken_zstr(spc), "SPC missing or invalid");
+
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> SPC (from URI) is: %s\n", spc);
+
+                stir_shaken_assert(e = stir_shaken_hash_entry_find(ca.sessions, STI_CA_SESSIONS_MAX, sp_code), "Session not found");
+                stir_shaken_assert(session = e->data, "CA session corrupted");
+
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> Authorization session in progress\n");
+
+                stir_shaken_assert(uri_has_secret <= 0, "Secret should not be set");
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> Handling authz challenge-details request\n");
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> SPC is: %s\n", spc);
+                stir_shaken_assert(STI_CA_SESSION_STATE_AUTHZ_SENT == session->state, "Wrong authorization state");
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> Authorization session challenge was:\n%s\n", session->authz_challenge);
+
+                stir_shaken_assert(STIR_SHAKEN_STATUS_OK == ca_create_session_challenge_details(ss, "pending", spc, authz_url, session), "AUTHZ Failed to produce challenge details");
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK)-> Sending challenge details:\n%s\n", session->authz_challenge_details);
+
+                free(http_req->response.mem.mem);
+                authzlen = strlen(session->authz_challenge_details);
+                stir_shaken_assert(http_req->response.mem.mem = malloc(authzlen + 1), "Malloc failed");
+                memset(http_req->response.mem.mem, 0, authzlen + 1);
+                strncpy(http_req->response.mem.mem, session->authz_challenge_details, authzlen);
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) HTTP/1.1 200 You are more than welcome. Here is your challenge:\r\nContent-Length: %lu\r\nContent-Type: application/json\r\n\r\n%s\r\n\r\n", strlen(session->authz_challenge_details), session->authz_challenge_details);
+
+                session->state = STI_CA_SESSION_STATE_AUTHZ_DETAILS_SENT;
+
+            }
+            break;
+
+        case STIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_REQ_AUTHZ:
+
+            {
+                char spc[STIR_SHAKEN_BUFLEN] = { 0 };
+                char *expires = "never", *validated = "just right now";
+                unsigned long long int sp_code = 0;
+                int uri_has_secret = 0;
+                unsigned long long secret = 0;
+                int authz_secret = 0;
+                jwt_t *spc_token_jwt = NULL;
+                jwt_t *spc_token_verified_jwt = NULL;
+                char *token = NULL;
+                char *spc_jwt_str = NULL;
+                const char *spc_str = NULL;
+                const char *spc_token = NULL;
+                stir_shaken_cert_t *cert = NULL;
+                const char *cert_url = NULL;
+                int authzlen = 0;
+
+                stir_shaken_hash_entry_t *e = NULL;
+                stir_shaken_ca_session_t *session = NULL;
+
+
+                printf("\n\nSTIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_REQ_AUTHZ\n\n");
+
+                stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_acme_api_uri_to_spc(ss, http_req->url, STI_CA_ACME_AUTHZ_URL, spc, STIR_SHAKEN_BUFLEN, &sp_code, &uri_has_secret, &secret), "ACME uri to SPC failed");
+                stir_shaken_assert(!stir_shaken_zstr(spc), "SPC missing or invalid");
+
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> SPC (from URI) is: %s\n", spc);
+
+                stir_shaken_assert(e = stir_shaken_hash_entry_find(ca.sessions, STI_CA_SESSIONS_MAX, sp_code), "Session not found");
+                stir_shaken_assert(session = e->data, "CA session corrupted");
+
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> Authorization session in progress\n");
+
+                if (http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_GET) {
+
+                    if (session->state = STI_CA_SESSION_STATE_POLLING) {
+
+                        polling++;
+
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> Handling polling request\n");
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> SPC is: %s\n", spc);
+
+                        stir_shaken_assert(!stir_shaken_zstr(session->authz_polling_status), "Oops, no polling status");
+
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> Sending polling status...\n");
+
+                        free(http_req->response.mem.mem);
+                        authzlen = strlen(session->authz_polling_status);
+                        stir_shaken_assert(http_req->response.mem.mem = malloc(authzlen + 1), "Malloc failed");
+                        memset(http_req->response.mem.mem, 0, authzlen + 1);
+                        strncpy(http_req->response.mem.mem, session->authz_polling_status, authzlen);
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) HTTP/1.1 200 OK\r\nContent-Length: %lu\r\nContent-Type: application/json\r\n\r\n%s\r\n\r\n", strlen(session->authz_polling_status), session->authz_polling_status);
+
+                        // continue
+                        session->state = STI_CA_SESSION_STATE_POLLING;
+                    } else {
+
+                        stir_shaken_assert(0, "Not implemented");
+                    }
+
+                } else {
+
+                    if (polling == 1) {
+                        // handle STI_CA_SESSION_STATE_AUTHZ_DETAILS_SENT state
+
+                        stir_shaken_assert(http_req->type == STIR_SHAKEN_HTTP_REQ_TYPE_POST, "Wrong HTTP req type");
+                        stir_shaken_assert(uri_has_secret, "Secret missing");
+
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> Handling response to authz challenge-details challenge\n");
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> SPC is: %s\n", spc);
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> Secret: %llu\n", secret);
+
+                        stir_shaken_assert(STI_CA_SESSION_STATE_AUTHZ_DETAILS_SENT == session->state, "Wrong authorization state");
+                        stir_shaken_assert(secret == session->authz_secret, "Bad secret for this authorization session");
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> Secret: OK\n");
+
+                        stir_shaken_assert(http_req->data && strlen(http_req->data), "Bad params, empty HTTP body");
+
+                        stir_shaken_assert(STIR_SHAKEN_STATUS_OK == ca_session_prepare_polling(ss, http_req->data, spc, expires, validated, session), "AUTHZ request failed, could not produce polling status");
+
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> Entering polling state...\n");
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) HTTP/1.1 200 OK, Processing... (you can do polling now)\r\n\r\n");
+                        session->state = STI_CA_SESSION_STATE_POLLING;
+                    } else {
+
+                        // Checking authotization
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> Verifying SPC token...\n");
+
+                        ca_verifying_spc_token = 1;
+
+                        // Extract SPC token from response token
+                        stir_shaken_assert(STIR_SHAKEN_STATUS_OK == ca_extract_spc_token_from_authz_response(&ca.ss, http_req->data, &spc_token, &spc_token_jwt), "AUTHZ request failed, authz response has invalid SPC token");
+                        stir_shaken_assert(spc_token, "Failed to get SPC token");
+                        stir_shaken_assert(spc_token_jwt, "Failed to get SPC token JWT");
+
+                        stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_jwt_verify(&ca.ss, spc_token, &cert, &spc_token_verified_jwt), "SPC token did not pass verification");
+                        stir_shaken_assert(cert, "Could not get PA cert");
+                        stir_shaken_destroy_cert(cert);
+                        free(cert);
+                        cert = NULL;
+                        jwt_free(spc_token_jwt);
+                        spc_token_jwt = NULL;
+
+                        stir_shaken_assert(spc_jwt_str = jwt_dump_str(spc_token_verified_jwt, 0), "Cannot dump SPC token JWT");
+
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> SPC token is:\n%s\n", spc_jwt_str);
+                        jwt_free_str(spc_jwt_str);
+                        spc_jwt_str = NULL;
+
+                        // And just a last check...
+
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> Verifying SPC from token against session...\n");
+
+                        stir_shaken_assert(STIR_SHAKEN_STATUS_OK == ca_verify_spc(&ca.ss, spc_token_verified_jwt, session->spc), "SPC from SPC token does not match session SPC");
+                        fprintif(STIR_SHAKEN_LOGLEVEL_BASIC, "(MOCK) -> [+] SP authorized\n");
+                        session->authorized = 1;
+                        jwt_free(spc_token_verified_jwt);
+                        spc_token_verified_jwt = NULL;
+
+authorization_result:
+
+                        // Set polling status, keep authorization session life for some time, allowing SP to query polling status and to download cert
+                        if (session->authz_polling_status) {
+                            free(session->authz_polling_status);
+                            session->authz_polling_status = NULL;
+                        }
+
+                        stir_shaken_assert(session->authz_polling_status = stir_shaken_acme_generate_auth_polling_status(&ca.ss, "valid", expires, validated, spc, session->authz_token, session->authz_url), "Failed to set polling status to 'valid'");
+
+                        if (!ca.keys.private_key) {
+
+                            fprintif(STIR_SHAKEN_LOGLEVEL_BASIC, "(MOCK) Loading keys...\n");
+                            stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_load_keys(ss, &ca.keys.private_key, NULL, ca.private_key_name, NULL, NULL, NULL), "Can't load CA private key");
+                        }
+
+                        if (!ca.cert.x) {
+                            fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) Loading CA certificate...\n");
+                            ca.cert.x = stir_shaken_load_x509_from_file(&ca.ss, ca.cert_name);
+                            stir_shaken_assert(ca.cert.x, "Error loading CA certificate");
+                        }
+
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) Issuing STI certificate...\n");
+
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) \t -> Loading CSR...\n");
+                        stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_load_x509_req_from_mem(&ca.ss, &session->sp.csr.req, session->sp.csr.pem), "Error loading CSR");
+
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) \t -> Generating cert...\n");
+                        stir_shaken_assert(session->sp.cert.x = stir_shaken_generate_x509_end_entity_cert_from_csr(&ca.ss, ca.cert.x, ca.keys.private_key, ca.issuer_c, ca.issuer_cn, session->sp.csr.req, ca.serial, ca.expiry_days, ca.tn_auth_list_uri), "Error creating SP certificate");
+
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) \t -> Configuring certificate...\n");
+                        snprintf(session->sp.cert_name, sizeof(session->sp.cert_name), "sp_%s_%llu_%zu.pem", spc, secret, time(NULL));
+
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) \t -> Saving certificate (%s)...\n", session->sp.cert_name);
+                        stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_x509_to_disk(&ca.ss, session->sp.cert.x, session->sp.cert_name), "Error saving SP certificate");
+
+                        fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> [++] STI certificate ready for download\n");
+
+                        if (spc_token_jwt) {
+                            jwt_free(spc_token_jwt);
+                            spc_token_jwt = NULL;
+                        }
+
+                        if (spc_token_verified_jwt) {
+                            jwt_free(spc_token_verified_jwt);
+                            spc_token_verified_jwt = NULL;
+                        }
+
+                        session->state = STI_CA_SESSION_STATE_POLLING;
+                    }
+
+                    fprintif(STIR_SHAKEN_LOGLEVEL_BASIC, "(MOCK) === OK\n");
+
+                }
+            }
+            break;
+
+        case STIR_SHAKEN_ACTION_TYPE_SP_CERT_DOWNLOAD:
+            {
+                char spc[STIR_SHAKEN_BUFLEN] = { 0 };
+                unsigned long long int sp_code = 0;
+                char authz_url[STIR_SHAKEN_BUFLEN] = { 0 };
+                char *authz_challenge_details = NULL;
+                int uri_has_secret = 0;
+                unsigned long long secret = 0;
+                int authz_secret = 0;
+                char spcbuf[STIR_SHAKEN_BUFLEN] = { 0 };
+                unsigned char cert[STIR_SHAKEN_BUFLEN] = { 0 };
+                unsigned char cert_b64[STIR_SHAKEN_BUFLEN] = { 0 };
+                int certlen = STIR_SHAKEN_BUFLEN;
+                int cert_b64_len = STIR_SHAKEN_BUFLEN;
+
+                stir_shaken_hash_entry_t *e = NULL;
+                stir_shaken_ca_session_t *session = NULL;
+
+
+                printf("\n\nSTIR_SHAKEN_ACTION_TYPE_SP_CERT_DOWNLOAD\n\n");
+
+                stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_acme_api_uri_to_spc(ss, http_req->url, STI_CA_ACME_CERT_REQ_URL, spc, STIR_SHAKEN_BUFLEN, &sp_code, &uri_has_secret, &secret), "ACME uri to SPC failed");
+                stir_shaken_assert(!stir_shaken_zstr(spc), "SPC missing or invalid");
+
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> SPC (from URI) is: %s\n", spc);
+
+                stir_shaken_assert(e = stir_shaken_hash_entry_find(ca.sessions, STI_CA_SESSIONS_MAX, sp_code), "Session not found");
+                stir_shaken_assert(session = e->data, "CA session corrupted");
+
+                stir_shaken_assert(!uri_has_secret, "Secret should not be set");
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> Handling authz challenge-details request\n");
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> SPC is: %s\n", spc);
+                stir_shaken_assert(STI_CA_SESSION_STATE_POLLING == session->state, "Wrong authorization state");
+
+                stir_shaken_assert(session->authorized, "Bad cert request, session is not authorized");
+
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) -> Authorization session in progress\n");
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) \t-> Replying to STI-SP certificate download request...\n");
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) \t\t-> Loading STI-SP certificate...\n");
+
+                stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_get_x509_raw(&ca.ss, session->sp.cert.x, cert, &certlen), "Error loading SP certificate");
+                stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_b64_encode(cert, certlen, cert_b64, cert_b64_len), "Error Base 64 encoding SP certificate");;
+
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) \t\t\t-> STI-SP certificate is:\n%s\n", cert);
+
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) \t\t-> Sending STI-SP certificate...\n");
+                fprintif(STIR_SHAKEN_LOGLEVEL_MEDIUM, "(MOCK) HTTP/1.1 200 OK\r\nContent-Length: %lu\r\nContent-Type: application/json\r\n\r\n%s\r\n\r\n", strlen((const char *)cert), cert);
+
+                free(http_req->response.mem.mem);
+                certlen = strlen(cert);
+                stir_shaken_assert(http_req->response.mem.mem = malloc(certlen + 1), "Malloc failed");
+                memset(http_req->response.mem.mem, 0, certlen + 1);
+                strncpy(http_req->response.mem.mem, cert, certlen);
+
+                session->state = STI_CA_SESSION_STATE_DONE;
+
+                stir_shaken_hash_entry_remove(ca.sessions, STI_CA_SESSIONS_MAX, sp_code, STIR_SHAKEN_HASH_TYPE_SHALLOW_AUTOFREE);
+            }
+            break;
+
+            // etc.
+
+        default:
+            printf("\n\nSTIR_SHAKEN_ACTION_TYPE unknown\n\n");
+            stir_shaken_assert(0, "Bad action type!");
+            return STIR_SHAKEN_STATUS_TERM;
+    }
+
+    return STIR_SHAKEN_STATUS_OK;
+}
+
+stir_shaken_status_t stir_shaken_unit_test_sp_cert_req(void)
+{
+    EVP_PKEY *pkey = NULL;
+    stir_shaken_status_t status = STIR_SHAKEN_STATUS_FALSE;
+    stir_shaken_context_t ss = { 0 };
+    const char *error_description = NULL;
+    stir_shaken_error_t error_code = STIR_SHAKEN_ERROR_GENERAL;
+
+    stir_shaken_http_req_t http_req = { 0 };
+    const char *kid = NULL, *nonce = NULL, *nb = NULL, *na = NULL;
+    char spc[STIR_SHAKEN_BUFLEN] = { 0 };
+    char url[STIR_SHAKEN_BUFLEN] = { 0 };
+    char *json = NULL;
+    char *spc_token = NULL;
+
+
+    sprintf(sp.private_key_name, "%s%c%s", path, '/', "all_sp_private_key.pem");
+    sprintf(sp.public_key_name, "%s%c%s", path, '/', "all_sp_public_key.pem");
+    sprintf(sp.csr_name, "%s%c%s", path, '/', "all_sp_csr.pem");
+    sprintf(sp.cert_name, "%s%c%s", path, '/', "all_sp_cert.crt");
+
+
+    // 1
+    // SP obtains SPC and SPC token from PA and can now construct CSR
+
+    printf("SP: Generate SP keys\n");
+
+    // Generate SP keys
+    sp.keys.priv_raw_len = STIR_SHAKEN_PRIV_KEY_RAW_BUF_LEN;
+    status = stir_shaken_generate_keys(&ss, &sp.keys.ec_key, &sp.keys.private_key, &sp.keys.public_key, sp.private_key_name, sp.public_key_name, sp.keys.priv_raw, &sp.keys.priv_raw_len);
+    PRINT_SHAKEN_ERROR_IF_SET
+        stir_shaken_assert(status == STIR_SHAKEN_STATUS_OK, "Err, failed to generate keys...");
+    stir_shaken_assert(sp.keys.ec_key != NULL, "Err, failed to generate EC key\n\n");
+    stir_shaken_assert(sp.keys.private_key != NULL, "Err, failed to generate private key");
+    stir_shaken_assert(sp.keys.public_key != NULL, "Err, failed to generate public key");
+
+    printf("SP: Create CSR\n");
+    sp.code = 1;
+    sprintf(spc, "%d", sp.code);
+    snprintf(sp.subject_c, STIR_SHAKEN_BUFLEN, "US");
+    snprintf(sp.subject_cn, STIR_SHAKEN_BUFLEN, "NewSTI-SP Number 1");
+
+    status = stir_shaken_generate_csr(&ss, sp.code, &sp.csr.req, sp.keys.private_key, sp.keys.public_key, sp.subject_c, sp.subject_cn);
+    PRINT_SHAKEN_ERROR_IF_SET
+        stir_shaken_assert(status == STIR_SHAKEN_STATUS_OK, "Err, generating CSR");
+
+    // Reqeust STI cetificate
+
+    kid = NULL;
+    nonce = NULL;
+    sprintf(url, "http://%s%s", STI_CA_ACME_ADDR, STI_CA_ACME_CERT_REQ_URL);
+    nb = "01 Apr 2020";
+    na = "01 Apr 2021";
+
+    // Set SPC token to this:
+    //
+    // SPC token encoded:
+    //
+    // eyJhbGciOiJFUzI1NiIsImlzc3VlciI6IlNpZ25hbFdpcmUgU1RJLVBBIiwidHlwIjoiSldUIiwieDV1IjoicGEuc2hha2VuLnNpZ25hbHdpcmUuY29tL3BhLnBlbSJ9.eyJub3RBZnRlciI6IjEgeWVhciBmcm9tIG5vdyIsIm5vdEJlZm9yZSI6InRvZGF5Iiwic3BjIjoiMSIsInR5cGUiOiJzcGMtdG9rZW4ifQ.i4h-yFR3Xofu35mzkq85o45iXMBfzBCuII4Se0g6n40KRJqKD8L1Wnzqf0xwbW7yN2nY8-LbGBmouq-uBhx09Q
+
+    // SPC token decoded:
+    //
+    //
+    //	{
+    //		"alg": "ES256",
+    //		"issuer": "SignalWire STI-PA",
+    //		"typ": "JWT",
+    //		"x5u": "pa.shaken.signalwire.com/pa.pem"
+    //	}
+    //	.
+    //	{
+    //		"notAfter": "1 year from now",
+    //	    "notBefore": "today",
+    //		"spc": "1",
+    //		"type": "spc-token"
+    //	}
+
+
+    spc_token = "eyJhbGciOiJFUzI1NiIsImlzc3VlciI6IlNpZ25hbFdpcmUgU1RJLVBBIiwidHlwIjoiSldUIiwieDV1IjoicGEuc2hha2VuLnNpZ25hbHdpcmUuY29tL3BhLnBlbSJ9.eyJub3RBZnRlciI6IjEgeWVhciBmcm9tIG5vdyIsIm5vdEJlZm9yZSI6InRvZGF5Iiwic3BjIjoiMSIsInR5cGUiOiJzcGMtdG9rZW4ifQ.i4h-yFR3Xofu35mzkq85o45iXMBfzBCuII4Se0g6n40KRJqKD8L1Wnzqf0xwbW7yN2nY8-LbGBmouq-uBhx09Q";
+    http_req.url = strdup(url);
+    http_req.remote_port = 8082;
+
+    if (STIR_SHAKEN_STATUS_OK != stir_shaken_sp_cert_req_ex(&ss, &http_req, kid, nonce, sp.csr.req, nb, na, spc, sp.keys.priv_raw, sp.keys.priv_raw_len, NULL, spc_token)) {
+        printf("STIR-Shaken: Failed to execute cert request\n");
+        PRINT_SHAKEN_ERROR_IF_SET
+
+            if (error_code == 2) {
+                printf("STIR-Shaken: Server is not available, skipping this test... If you want to see the results, you can run this test only with: ./stir_shaken_test_all\n");
+                return STIR_SHAKEN_STATUS_OK;
+            }
+
+        return STIR_SHAKEN_STATUS_TERM;
+    }
+
+    stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_load_x509_from_mem(&ss, &sp.cert.x, NULL, http_req.response.mem.mem), "Failed to load X509 from memory");
+    stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_x509_to_disk(&ss, sp.cert.x, "test/run/all_sp.pem"), "Failed to save the certificate");
+
+
+    // SP cleanup	
+    stir_shaken_sp_destroy(&sp);
+    stir_shaken_destroy_http_request(&http_req);
+
+    return STIR_SHAKEN_STATUS_OK;
+}
+
+int main(int argc, char ** argv)
+{
+    stir_shaken_assert(STIR_SHAKEN_STATUS_OK == stir_shaken_do_init(NULL, NULL, NULL, STIR_SHAKEN_LOGLEVEL_HIGH), "Cannot init lib");
+
+    if (argc == 1) {
+
+        // MOCK http transfers by default
+        stir_shaken_make_http_req = stir_shaken_make_http_req_mock;
+
+    } else if (argc > 1 && !stir_shaken_zstr(argv[1]) && !strcmp(argv[1], "nomock")) {
+
+        // do not MOCK
+    } else {
+        printf("ERR: this program takes no argument or one argument which must be 'nomock'\n");
+        exit(EXIT_FAILURE);
+    }
+
+    if (stir_shaken_dir_exists(path) != STIR_SHAKEN_STATUS_OK) {
+
+        if (stir_shaken_dir_create_recursive(path) != STIR_SHAKEN_STATUS_OK) {
+
+            printf("ERR: Cannot create test dir\n");
+            return -1;
+        }
+    }
+
+    if (stir_shaken_unit_test_sp_cert_req() != STIR_SHAKEN_STATUS_OK) {
+
+        return -2;
+    }
+
+    stir_shaken_do_deinit();
+    stir_shaken_ca_destroy(&ca);
+
+    printf("OK\n");
+
+    return 0;
+}

--- a/util/src/stir_shaken_ca.c
+++ b/util/src/stir_shaken_ca.c
@@ -414,7 +414,7 @@ stir_shaken_status_t ca_sp_cert_req_reply_challenge(stir_shaken_context_t *ss, s
 	}
 
 	// TODO queue challenge task/job
-	session = stir_shaken_ca_session_create(sp_code, gen_authz_challenge, csr);
+	session = stir_shaken_ca_session_create(sp_code, gen_authz_challenge, csr, 0);
 	if (!session) {
 		stir_shaken_set_error(ss, "Cannot create authorization session", STIR_SHAKEN_ERROR_ACME_SESSION_CREATE);
 		goto fail;


### PR DESCRIPTION
Mock STIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_INIT and STIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_REQ_AUTHZ_DETAILS actions
Mock polling prepare part of STIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_REQ_AUTHZ action
MOCK STIR_SHAKEN_ACTION_TYPE_SP_CERT_REQ_SP_REQ_AUTHZ and STIR_SHAKEN_ACTION_TYPE_SP_CERT_DOWNLOAD
and extra case for ca_verifying_spc_token (mock for http req made by CA [while downloading PA cert])
This test will mock HTTP transfers by default unless executed with 'nomock' argument,
then it will perform HTTP transfers as usual.
Update README.md.
Fix leaks

Unit testing: print test log if test fails for ease of troubleshooting