### PR TITLE
Ensure stir_shaken_cert_copy() also copies provided chain certificates

### DIFF
--- a/src/stir_shaken_ssl.c
+++ b/src/stir_shaken_ssl.c
@@ -1717,6 +1717,7 @@ stir_shaken_status_t stir_shaken_cert_copy(stir_shaken_context_t *ss, stir_shake
 	memset(dst, 0, sizeof(*dst));
 
 	dst->x = src->x;
+	dst->xchain = src->xchain;
 	strncpy(dst->public_url, src->public_url, STIR_SHAKEN_BUFLEN);
 	X509_up_ref(src->x);
 


### PR DESCRIPTION
When caching certificates it is currently not possible to provide required intermediary certificates to the library.

Currently, the first verification process of a certificate+intermediary will validate successfully, however when the cache process provides the cert+intermediary the validation will fail.  This patch ensures the cache callback is able to provide required intermediary certificates to the library.